### PR TITLE
fix: handle compose-escaped bcrypt hashes for Caddy basic auth

### DIFF
--- a/scripts/deploy/azure_deploy_container.py
+++ b/scripts/deploy/azure_deploy_container.py
@@ -862,8 +862,9 @@ def main(argv: list[str] | None = None, repo_root_override: Path | None = None) 
 
         basic_auth_hash: str | None = None
         if basic_auth_hash_or_password:
-            if looks_like_bcrypt_hash(basic_auth_hash_or_password):
-                basic_auth_hash = basic_auth_hash_or_password
+            normalized = deploy_helpers.normalize_bcrypt_hash(basic_auth_hash_or_password)
+            if deploy_helpers.looks_like_bcrypt_hash(normalized):
+                basic_auth_hash = normalized
             else:
                 # Treat as plaintext password and compute bcrypt hash.
                 try:

--- a/scripts/deploy/azure_deploy_container_helpers.py
+++ b/scripts/deploy/azure_deploy_container_helpers.py
@@ -636,9 +636,24 @@ def truthy(value: str | None) -> bool:
 
 
 def looks_like_bcrypt_hash(value: str) -> bool:
-    v = (value or "").strip()
+    v = normalize_bcrypt_hash(value)
     # Caddy basicauth bcrypt hashes typically start with $2a$, $2b$, $2y$.
     return v.startswith("$2")
+
+
+def normalize_bcrypt_hash(value: str | None) -> str:
+    """Normalize bcrypt hashes that may be escaped for docker-compose.
+
+    In docker-compose files, `$` is used for interpolation, so bcrypt hashes are
+    often written with `$$` to preserve literal `$` characters.
+
+    Example:
+      $$2a$$14$$...  ->  $2a$14$...
+    """
+    v = (value or "").strip()
+    if v.startswith("$$2"):
+        v = v.replace("$$", "$")
+    return v
 
 
 def bcrypt_hash_password(password: str, *, cost: int = 14) -> str:

--- a/scripts/deploy/generate_bcrypt_hash.py
+++ b/scripts/deploy/generate_bcrypt_hash.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Generate a Caddy-compatible bcrypt hash for Basic Auth.
+
+This avoids putting plaintext passwords on the command line.
+
+Usage:
+  ./scripts/deploy/generate_bcrypt_hash.py
+  ./scripts/deploy/generate_bcrypt_hash.py --cost 14
+  ./scripts/deploy/generate_bcrypt_hash.py --compose-escape
+
+Notes:
+- docker-compose uses `$` for interpolation; to store bcrypt hashes in compose
+  YAML safely, you often need to replace `$` with `$$`.
+- For Azure deployments, `scripts/deploy/azure_deploy_container.py` normalizes
+  `$$2...` back to `$2...` automatically.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+
+from scripts.deploy.azure_deploy_container_helpers import bcrypt_hash_password
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate bcrypt hash for Caddy basicauth")
+    parser.add_argument("--cost", type=int, default=14, help="bcrypt cost factor (4-31). Default: 14")
+    parser.add_argument(
+        "--compose-escape",
+        action="store_true",
+        help="Replace '$' with '$$' for safe inclusion in docker-compose YAML",
+    )
+    args = parser.parse_args()
+
+    password = getpass.getpass("Basic Auth password: ").strip()
+    if not password:
+        raise SystemExit("Password must be non-empty")
+
+    hashed = bcrypt_hash_password(password, cost=args.cost)
+    if args.compose_escape:
+        hashed = hashed.replace("$", "$$")
+
+    print(hashed)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
- Normalize 5286152.. style hashes (compose escaping) to ..

- Add helper to generate bcrypt hashes safely