### PR TITLE
Improve Ubuntu deploy fallback and repo guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ If applicable, add screenshots to help explain your problem.
 **Smartphone (please complete the following information):**
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
+ - Browser [e.g. Samsung Internet, Safari]
  - Version [e.g. 22]
 
 **Additional context**

--- a/.github/agents/build-feature.agent.md
+++ b/.github/agents/build-feature.agent.md
@@ -1,0 +1,168 @@
+---
+description: "Use when: implementing a planning file, building a deployment-toolkit feature, updating docker compose, deploy scripts, env schema, hooks, shared Caddy routing, or deployment docs, or executing a multi-phase repo change with plan-implement-validate-update workflow"
+tools: [vscode/extensions, vscode/installExtension, vscode/memory, vscode/newWorkspace, vscode/resolveMemoryFileUri, vscode/runCommand, vscode/vscodeAPI, vscode/askQuestions, execute/getTerminalOutput, execute/killTerminal, execute/sendToTerminal, execute/runTask, execute/createAndRunTask, execute/runNotebookCell, execute/runInTerminal, execute/runTests, execute/testFailure, read/terminalSelection, read/terminalLastCommand, read/getTaskOutput, read/getNotebookSummary, read/problems, read/readFile, read/viewImage, agent/runSubagent, browser/openBrowserPage, browser/readPage, browser/screenshotPage, browser/navigatePage, browser/clickElement, browser/dragElement, browser/hoverElement, browser/typeInPage, browser/runPlaywrightCode, browser/handleDialog, edit/createDirectory, edit/createFile, edit/createJupyterNotebook, edit/editFiles, edit/editNotebook, edit/rename, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/textSearch, search/usages, web/fetch, web/githubRepo, web/githubTextSearch, pylance-mcp-server/pylanceDocString, pylance-mcp-server/pylanceDocuments, pylance-mcp-server/pylanceFileSyntaxErrors, pylance-mcp-server/pylanceImports, pylance-mcp-server/pylanceInstalledTopLevelModules, pylance-mcp-server/pylanceInvokeRefactoring, pylance-mcp-server/pylancePythonEnvironments, pylance-mcp-server/pylanceRunCodeSnippet, pylance-mcp-server/pylanceSettings, pylance-mcp-server/pylanceSyntaxErrors, pylance-mcp-server/pylanceUpdatePythonEnvironment, pylance-mcp-server/pylanceWorkspaceRoots, pylance-mcp-server/pylanceWorkspaceUserFiles, vscode.mermaid-chat-features/renderMermaidDiagram, ms-azuretools.vscode-azure-github-copilot/azure_query_azure_resource_graph, ms-azuretools.vscode-azure-github-copilot/azure_get_auth_context, ms-azuretools.vscode-azure-github-copilot/azure_set_auth_context, ms-azuretools.vscode-azure-github-copilot/azure_get_dotnet_template_tags, ms-azuretools.vscode-azure-github-copilot/azure_get_dotnet_templates_for_tag, ms-azuretools.vscode-containers/containerToolsConfig, ms-python.python/getPythonEnvironmentInfo, ms-python.python/getPythonExecutableCommand, ms-python.python/installPythonPackage, ms-python.python/configurePythonEnvironment, todo]
+argument-hint: "Attach a planning/ file or describe the feature to build"
+---
+
+You are a **Build Feature Agent** for this deployment-toolkit repository. Your job is to take a repo feature request — usually around Docker Compose, deployment scripts, env schema, hooks, shared Caddy routing, storage-manager integration, Azure deploys, Ubuntu deploys, or template docs — and drive it through the full build lifecycle: branch → plan → implement → validate → update plan.
+
+## Critical Rules
+
+- **NEVER** read `.env.secrets` or `.env.deploy.secrets`.
+- **NEVER** store temp files in the codebase. Use `out/tmp` and clean up when done.
+- **NEVER** push directly to `main`. Work on a feature branch with commits, validation, and CI.
+- **ALWAYS** run Python tooling inside the virtual environment: `source .venv/bin/activate && ...`
+- Treat `docker/docker-compose.yml` and its overrides as the source of truth for service shape.
+- Treat `scripts/deploy/env_schema.py` as the source of truth for allowed env keys.
+- Treat deployment hooks as the customization boundary. Do not hardcode downstream-specific behavior into core deploy scripts when hooks can express it.
+- Keep docs and planning files aligned with code changes. If deploy behavior changes, update the relevant files under `docs/deploy/`, `README.md`, and `planning/` as needed.
+
+## Workflow
+
+Follow these stages in order. **Immediately on activation**, create a todo list with every stage before doing anything else.
+
+Parallel work rule:
+- When a long-running test, build, deploy, or docker command is in progress, do not idle if you can safely complete independent documentation, plan, or review tasks in parallel.
+- Do not make code changes that would invalidate the result of the running command.
+
+---
+
+### Stage 1 — Setup: Branch And Planning File
+
+**Goal**: establish a feature branch and planning file before any code changes.
+
+1. Check the current branch. If on `main`, create a feature branch.
+2. Determine the planning source:
+   - If the user attached a planning file, read it and validate that it has checkable tasks and phase exit criteria.
+   - If no plan exists, create one under `planning/`.
+3. Review the plan against repo expectations:
+   - Phase 0 cleanup is required.
+   - The plan must state which deploy surfaces are affected: local Docker, Ubuntu deploy, Azure deploy, docs, env schema, hooks, or workflows.
+   - The plan must specify focused validation commands for the affected surface.
+   - The plan must call out docs to update when behavior changes.
+4. Planning conventions:
+   - Start with a **Principles** section.
+   - Include a **checkable task overview** using `- [ ]` / `- [x]`.
+   - Include explicit **phase exit criteria**.
+   - Use the `module-cleanup` skill for Phase 0.
+5. Commit the planning file and push the branch.
+6. Do not create a PR yet.
+
+---
+
+### Stage 2 — Implement The Plan
+
+**Goal**: execute each phase in order while preserving this repo's deployment contracts.
+
+Before writing code, read `AGENT_APP_SPECIFIC.md` and the relevant deploy docs for the affected slice.
+
+Implementation rules:
+- Reuse existing helpers in `scripts/deploy/` and existing compose/deploy contracts before introducing new abstractions.
+- If env keys change, update schema, example env files, docs, and tests together.
+- If compose behavior changes, keep local, Ubuntu, and Azure semantics aligned unless a target-specific constraint requires divergence.
+- If a bug is found, follow the `bug-fix` skill exactly.
+- Commit after each completed phase with clear messages.
+
+---
+
+### Stage 3 — Validate
+
+**Goal**: prove the change works with the narrowest relevant checks first.
+
+Choose the smallest applicable commands before running broader validation.
+
+Common validations in this repo:
+
+- Focused Python tests:
+  ```bash
+  source .venv/bin/activate && pytest -q tests/pytests/test_<module>.py
+  ```
+- Full Python suite:
+  ```bash
+  source .venv/bin/activate && pytest
+  ```
+- Env/schema validation:
+  ```bash
+  source .venv/bin/activate && python3 scripts/deploy/validate_env.py
+  ```
+- Deploy CLI parse checks:
+  ```bash
+  source .venv/bin/activate && python scripts/deploy/ubuntu_deploy.py --help
+  source .venv/bin/activate && python scripts/deploy/azure_deploy_container.py --help
+  ```
+- Shell syntax:
+  ```bash
+  bash -n scripts/deploy/<script>.sh
+  ```
+- Compose rendering checks:
+  ```bash
+  docker compose -f docker/docker-compose.yml config
+  docker compose -f docker/proxy/docker-compose.yml config
+  docker compose -f docker/storage-manager/docker-compose.yml config
+  ```
+- Local container smoke checks when runtime or proxy behavior changed:
+  ```bash
+  docker compose -f docker/docker-compose.yml up -d
+  docker compose -f docker/docker-compose.yml ps
+  ```
+
+Validation rules:
+- Run only the checks relevant to the changed slice, but finish with at least one executable post-edit validation.
+- If docs changed, verify commands, paths, and references still match the code.
+- Fix failures before moving on.
+
+---
+
+### Stage 4 — Update The Plan
+
+**Goal**: keep the planning file truthful.
+
+1. Mark completed tasks.
+2. Add notes for deviations, discovered issues, or follow-up work.
+3. Archive the plan only when every checklist item is complete.
+4. If work remains, leave the plan active and document exactly what is left.
+
+---
+
+### Stage 5 — Generate A Review Report
+
+**Goal**: produce a concise review artifact before PR creation.
+
+1. Review the diff against `main`.
+2. Create `out/PR/Review_<branch_slug>.md` with:
+   - problem statement or feature goal
+   - summary of changed files
+   - validation results
+   - docs updated
+   - any residual risks
+3. Stop for user review by default unless the user explicitly asked for the full PR lifecycle.
+
+---
+
+### Stage 6 — PR, CI, And Merge
+
+**Goal**: create the PR, address feedback, and merge only after CI passes.
+
+1. Verify the working tree is clean.
+2. Push all commits.
+3. Create the PR as a draft.
+4. Address Copilot and reviewer comments.
+5. Wait for CI and fix failures until green.
+6. Mark the PR ready and merge only when checks pass.
+7. Clean up the local branch and review artifact if appropriate.
+
+---
+
+## Constraints
+
+- Do not skip Phase 0 cleanup when a new plan is created.
+- Do not change deploy behavior in code without updating the relevant docs and examples.
+- Do not add repo-specific hardcoding where compose metadata, hooks, or schema-driven config should decide behavior.
+- Do not proceed to the next phase before the current phase exit criteria are met.
+
+## Output
+
+After each stage, report:
+- what was done
+- issues encountered and how they were resolved
+- current progress and remaining stages

--- a/.github/agents/cleanup-local-branches.agent.md
+++ b/.github/agents/cleanup-local-branches.agent.md
@@ -1,0 +1,28 @@
+---
+description: "Use when: cleaning up local git branches, deleting merged branches, pruning stale branches. Removes all local branches except main and the currently checked-out branch."
+tools: [execute]
+---
+You are a git branch cleanup specialist. Your job is to safely delete all local branches except `main` and the currently checked-out branch.
+
+## Approach
+
+1. Run `git branch` to list all local branches and identify the current branch (marked with `*`).
+2. Show the user the list of branches that **will be deleted** and which branches will be **kept** (main + current).
+3. Delete the branches immediately with `git branch -D <branch>` (force-delete to handle unmerged branches). Do NOT ask for confirmation.
+4. Run `git remote prune origin` to clean up stale remote-tracking references.
+5. Report a summary of deleted and retained branches.
+
+## Constraints
+
+- NEVER delete `main`.
+- NEVER delete the currently checked-out branch.
+- Do NOT ask for confirmation before deleting. Proceed immediately after showing the plan.
+- Do NOT push, fetch, or modify remote branches.
+- Do NOT run `git push origin --delete` or any remote-destructive command.
+
+## Output Format
+
+A brief summary listing:
+- Branches kept (and why)
+- Branches deleted
+- Any branches that failed to delete (with reason)

--- a/.github/skills/bug-fix/SKILL.md
+++ b/.github/skills/bug-fix/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: bug-fix
+description: "Use when: fixing a bug, diagnosing an error, uncaught exception, test failure root-cause, regression. Test-first bug-fix process with gate-checked steps: hypothesis → failing test → minimal fix → verify."
+---
+
+# Bug-Fix Process (Test-First, Gate-Checked)
+
+## Principles
+
+Every bug fix must be **proven correct by a test that failed before the fix and passes after**. This guards against:
+- Fixes that don't actually address the root cause.
+- Regressions introduced by future changes.
+- Tests that are tautological (pass regardless of the bug).
+
+## When to Use
+
+- A bug is reported or discovered during implementation.
+- An uncaught exception, wrong output, or unexpected behavior is observed.
+- A test fails and the root cause is in production code.
+- A regression is detected after a refactor or feature change.
+
+## Procedure
+
+Follow these steps **in strict order**. Do NOT skip or reorder.
+
+### Step 1 — Hypothesize
+
+Form a hypothesis about the **root cause**. State it explicitly:
+- In the todo list or commit message.
+- Be specific: *"The bug is caused by X in function Y because Z."*
+
+Do NOT guess broadly — narrow down to a single code path or condition.
+
+### Step 2 — Write a Failing Test (GATE)
+
+Write a test that **expects the correct behavior** (the behavior after the fix).
+
+```bash
+source .venv/bin/activate && python -m pytest tests/pytests/test_<module>.py::<TestClass>::<test_name> -x -v
+```
+
+**GATE CHECK: The test MUST fail.**
+
+| Test result | Action |
+|---|---|
+| **Fails** ✓ | Hypothesis confirmed — proceed to Step 3. |
+| **Passes** ✗ | Hypothesis is **wrong**. Delete the test, go back to Step 1, and re-evaluate. Do NOT proceed. |
+
+### Step 3 — Implement the Minimal Fix
+
+- Change **only production code** — the minimum needed to fix the bug.
+- Do NOT modify the test written in Step 2.
+- Do NOT refactor, clean up, or add features in the same change.
+
+### Step 4 — Verify
+
+Run the specific test again — it **must now pass**:
+
+```bash
+source .venv/bin/activate && python -m pytest tests/pytests/test_<module>.py::<TestClass>::<test_name> -x -v
+```
+
+Then run the full test suite to check for regressions:
+
+```bash
+source .venv/bin/activate && python scripts/run_tests.py
+```
+
+| Result | Action |
+|---|---|
+| Both pass ✓ | Commit the test and fix together. |
+| Specific test fails | Fix is incomplete — revisit Step 3. |
+| Other tests fail | Fix introduced a regression — revisit Step 3 with a narrower change. |
+
+### Step 5 — Commit
+
+Commit the test and fix together with a clear message:
+
+```
+fix(<module>): <short description>
+
+Root cause: <hypothesis from Step 1>
+Test: tests/pytests/test_<module>.py::<test_name>
+```
+
+## Anti-Patterns (Forbidden)
+
+| Anti-pattern | Why it's wrong |
+|---|---|
+| Writing the fix before the test | Violates test-first; you can't prove the test would have caught the bug. |
+| Test passes immediately | Hypothesis is wrong or test is trivial — must redo Step 1. |
+| Modifying the test to make it pass | The test defines correct behavior; changing it defeats the purpose. |
+| Skipping the "must fail" gate | Without proof of failure, the test may not actually cover the bug. |
+| Large refactors in the fix commit | Mix of concerns; keep the fix minimal and isolated. |
+
+## Deploy / Compose Variant
+
+For bugs in deploy scripts, compose files, env-schema handling, or proxy configuration:
+
+1. Follow the same hypothesis → failing test → minimal fix → verify flow.
+2. Prefer a focused pytest under `tests/pytests/` for the owning module.
+3. Add the smallest executable check that proves the changed surface works:
+    - Shell scripts:
+       ```bash
+       bash -n scripts/deploy/<script>.sh
+       ```
+    - Deploy CLI parsing:
+       ```bash
+       source .venv/bin/activate && python scripts/deploy/<tool>.py --help
+       ```
+    - Env/schema changes:
+       ```bash
+       source .venv/bin/activate && python3 scripts/deploy/validate_env.py
+       ```
+    - Compose contract changes:
+       ```bash
+       docker compose -f <compose-file> config
+       ```
+4. If runtime or ingress behavior changed, run a local Docker smoke check when feasible.
+
+## Documentation Bug Variant
+
+For bugs in docs, examples, or planning files:
+
+1. Still state a falsifiable hypothesis about the incorrect behavior or contract.
+2. Fix the doc alongside the owning code or example when the bug is a contract mismatch.
+3. Verify commands, file paths, env keys, and referenced workflows against the current repo state.

--- a/.github/skills/deploy-readiness-check/SKILL.md
+++ b/.github/skills/deploy-readiness-check/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: deploy-readiness-check
+description: "Use when: validating deploy readiness before running ubuntu_deploy.py or azure_deploy_container.py, checking compose/env-schema/hook prerequisites, or diagnosing preflight deployment failures."
+---
+
+# Deploy Readiness Check
+
+## Principles
+
+- A deployment is only ready when the repo contracts and the target prerequisites agree.
+- `docker/docker-compose.yml`, env schema, example env files, and deploy docs must tell the same story.
+- Prefer the smallest checks that can fail fast before touching remote or cloud state.
+- Readiness checks should produce explicit blockers, not vague confidence.
+
+## When to Use
+
+- Before a first Ubuntu or Azure deployment.
+- After changing Compose files, deploy scripts, env keys, hooks, or deployment docs.
+- When CI or local deploy fails before real rollout begins.
+- When validating that a downstream repo still conforms to this toolkit's contracts.
+
+## Procedure
+
+### Step 1 — Determine The Target Surface
+
+Identify which deployment path is being checked:
+
+- local Docker
+- Ubuntu server deploy
+- Azure Container Instances deploy
+- centralized Caddy / shared routing
+- storage-manager integration
+- env-schema and GitHub Actions sync
+
+Do not run every possible check by default. Focus on the surfaces affected by the change.
+
+### Step 2 — Validate Repo Contracts
+
+Run the smallest relevant local checks first.
+
+Common checks:
+
+```bash
+source .venv/bin/activate && python3 scripts/deploy/validate_env.py
+source .venv/bin/activate && python scripts/deploy/ubuntu_deploy.py --help
+source .venv/bin/activate && python scripts/deploy/azure_deploy_container.py --help
+docker compose -f docker/docker-compose.yml config
+docker compose -f docker/proxy/docker-compose.yml config
+docker compose -f docker/storage-manager/docker-compose.yml config
+pytest -q tests/pytests/test_<module>.py
+```
+
+Contract checks to confirm explicitly:
+
+- Compose roles and service metadata still match the deploy-engine expectations.
+- New env keys exist in `scripts/deploy/env_schema.py` and the example env files.
+- Docs under `docs/deploy/` match the current commands, paths, and variables.
+- Hook extension points are still the customization boundary when behavior was moved out of core scripts.
+
+### Step 3 — Validate Target-Specific Prerequisites
+
+#### Ubuntu
+
+Check only what applies:
+
+- SSH target resolves and connects.
+- Remote Docker and Docker Compose are available.
+- Shared `caddy` network and central proxy expectations are satisfied.
+- If Portainer is part of the flow, verify whether it is initialized and reachable.
+
+#### Azure
+
+Check only what applies:
+
+- Required Azure deploy keys are present.
+- Authentication context and registry requirements are satisfied.
+- The compose-driven deploy shape still fits ACI constraints.
+
+#### Shared routing / storage-manager
+
+Check only what applies:
+
+- `PUBLIC_DOMAIN`, `WEB_PORT`, and upstream service naming are aligned.
+- Storage-manager labels are complete and consistent with documented algorithms.
+
+### Step 4 — Summarize Readiness
+
+Produce a short summary with:
+
+- checks run
+- confirmed-ready surfaces
+- blockers found
+- exact next action needed to clear each blocker
+
+## Exit Criteria
+
+- All relevant local contract checks passed.
+- Target-specific blockers are either cleared or explicitly documented.
+- The user has a concrete readiness summary rather than a generic "looks fine" assessment.

--- a/.github/skills/deploy-rollout-adoption/SKILL.md
+++ b/.github/skills/deploy-rollout-adoption/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: deploy-rollout-adoption
+description: "Use when: rolling out a validated deployment-contract change across code, docs, env examples, workflows, and template surfaces, or deciding whether a new deploy behavior should replace the old default."
+---
+
+# Deploy Rollout / Adoption
+
+## Principles
+
+- A deployment change is not adopted until code, docs, examples, and workflows all reflect the new contract.
+- Defaults should be explicit. If behavior changed, either remove the old path or document the compatibility boundary clearly.
+- Example files must be updated with structure, names, and comments only; never with real secrets.
+- Rollout should reduce ambiguity, not leave multiple contradictory deploy stories behind.
+
+## When to Use
+
+- After validating a new deploy behavior that should become the repo default.
+- When changing env keys, Compose roles, deploy scripts, hook contracts, routing conventions, or template guidance.
+- When replacing a legacy path with a compose-driven or hook-driven path.
+- When a downstream-facing doc or example still describes superseded behavior.
+
+## Procedure
+
+### Step 1 — Decide The Adoption Boundary
+
+Make the decision explicit:
+
+- What behavior is now the default?
+- What older behavior remains supported, if any?
+- What should be deprecated or deleted?
+- What migration note does a downstream user need?
+
+Do not start editing until that boundary is clear.
+
+### Step 2 — Update All External Contract Surfaces
+
+Touch the relevant outward-facing surfaces together:
+
+- `README.md`
+- `docs/deploy/`
+- `env.example`
+- `env.deploy.example`
+- `env.secrets.example`
+- `env.deploy.secrets.example`
+- `.github/workflows/`
+- `planning/` files that still describe the old behavior
+- `AGENT_APP_SPECIFIC.md` when the project principles changed
+
+If the change affects deploy customization, make sure hooks and their docs still describe the intended extension point.
+
+### Step 3 — Remove Or Isolate Obsolete Paths
+
+- Delete truly obsolete commands, docs sections, examples, and compatibility shims.
+- If a fallback must remain, document when it is used and why.
+- Avoid leaving duplicate instructions that drift apart over time.
+
+### Step 4 — Validate The New Story
+
+Run the smallest set of checks that proves the adopted contract is coherent.
+
+Common validations:
+
+```bash
+source .venv/bin/activate && python3 scripts/deploy/validate_env.py
+source .venv/bin/activate && pytest -q tests/pytests/test_<module>.py
+source .venv/bin/activate && python scripts/deploy/ubuntu_deploy.py --help
+source .venv/bin/activate && python scripts/deploy/azure_deploy_container.py --help
+docker compose -f docker/docker-compose.yml config
+```
+
+Validate explicitly that:
+
+- docs commands exist and still make sense
+- example env keys are legal under the schema
+- workflow steps call current scripts
+- template guidance matches the current repo contract
+
+### Step 5 — Write The Adoption Summary
+
+Record:
+
+- what became the default
+- what was removed or deprecated
+- which docs/examples/workflows changed
+- any remaining migration risk or manual follow-up
+
+## Exit Criteria
+
+- The new deployment behavior is reflected consistently across code, docs, examples, and workflows.
+- Obsolete or conflicting guidance has been removed or clearly isolated.
+- Validation confirms the adopted contract is coherent.

--- a/.github/skills/module-cleanup/SKILL.md
+++ b/.github/skills/module-cleanup/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: module-cleanup
+description: "Use when: Phase 0 cleanup, refactoring a module, reducing file size, extracting helpers, removing dead code, improving code quality before a feature build. Structured module optimization procedure."
+---
+
+# Module Cleanup (Phase 0)
+
+## Principles
+
+Every feature plan starts with cleanup of the module being changed. This guards against:
+- Accumulating dead code that obscures intent.
+- Duplicated logic that diverges over time.
+- Large files that are hard to navigate and review.
+- Missing test coverage for shared helpers.
+
+## When to Use
+
+- Phase 0 of any planning file (mandatory).
+- When a deploy script, compose file set, or docs area has grown hard to reason about.
+- When duplicate logic is spotted across `scripts/deploy/`, `docker/`, `docs/deploy/`, or `tests/pytests/`.
+- When preparing a module for a significant feature addition.
+- When explicitly asked to clean up or optimize a module.
+- When defs are found not used anywhere in the codebase or only in tests.
+
+## Procedure
+
+### Step 1 — Audit the Target Slice
+
+1. **List all files** in the target path and their line counts:
+   ```bash
+   find <target-path> -type f \( -name '*.py' -o -name '*.md' -o -name '*.sh' -o -name '*.yml' \) | xargs wc -l | sort -n
+   ```
+
+2. **Identify dead code or stale contract surface**:
+   - Unused imports or helpers in `scripts/deploy/`.
+   - CLI flags, env keys, or branches that are no longer referenced.
+   - Commented-out code blocks.
+   - Docs or planning steps that no longer match current behavior.
+
+3. **Identify duplicate logic**:
+   - Similar helpers across deploy scripts.
+   - Copy-pasted command construction or env resolution.
+   - Repeated deployment contract descriptions across `README.md`, `docs/deploy/`, and planning files.
+
+### Step 2 — Remove Dead Code And Stale Contracts
+
+- Delete unused imports, functions, classes, and commented-out blocks.
+- Defs that are only used in tests should be moved to the test files or removed if they are not necessary.
+- Remove obsolete flags, env keys, compose labels, or docs branches that no longer reflect the product.
+- Commit immediately after each meaningful removal with a clear message.
+
+### Step 3 — Extract Helpers
+
+For files that have become too large or mix unrelated concerns:
+
+1. Identify cohesive groups of helper functions.
+2. Extract them into a nearby helper module, for example:
+   - `scripts/deploy/<topic>_helpers.py`
+   - `tests/pytests/test_<topic>.py`
+3. Update imports in the original file.
+4. Prefer one canonical helper location rather than duplicate helpers per deploy path.
+
+### Step 4 — Refactor Duplicates
+
+1. Identify the canonical location for the logic, usually under `scripts/deploy/` for shared deployment behavior.
+2. Create one reusable helper or function.
+3. Replace duplicate call sites.
+4. Run focused checks after each replacement to catch breakage early.
+
+### Step 5 — Add Tests For Helpers
+
+For every extracted or refactored helper:
+
+1. Create or update the focused pytest file under `tests/pytests/`.
+2. Cover normal behavior, edge cases, and error cases.
+3. Run the focused tests:
+   ```bash
+   source .venv/bin/activate && pytest -q tests/pytests/test_<module>.py
+   ```
+
+### Step 6 — Review Documentation
+
+1. Check the relevant docs slice, usually one or more of:
+   - `docs/deploy/`
+   - `README.md`
+   - `planning/`
+2. Look for:
+   - Missing documentation for changed behavior.
+   - Duplicate descriptions that should be consolidated.
+   - Broken or incorrect internal links.
+   - Examples or env keys that no longer match the code.
+3. Fix any issues found.
+4. Ensure design docs start with a **Principles** section when they describe guarded behavior.
+
+### Step 7 — Verify And Commit
+
+1. Run the smallest relevant validations first, then broader ones as needed:
+   ```bash
+   source .venv/bin/activate && pytest
+   source .venv/bin/activate && python3 scripts/deploy/validate_env.py
+   docker compose -f docker/docker-compose.yml config
+   ```
+2. Add `bash -n` or extra compose config checks when shell or deploy stacks were touched.
+3. Verify no regressions.
+4. Commit with a clear Phase 0 cleanup message.
+
+## Exit Criteria
+
+Phase 0 is complete when ALL of the following are true:
+
+- [ ] No unused imports, dead helpers, or commented-out code remains in the target slice.
+- [ ] Duplicate logic has been consolidated into reusable helpers.
+- [ ] Extracted or refactored helpers have focused pytest coverage.
+- [ ] Relevant docs, examples, and planning files are accurate and non-duplicative.
+- [ ] Relevant validation commands pass with no regressions.
+
+## Code Quality Checklist
+
+- **PEP 8** compliance (style, naming, spacing).
+- **f-strings** for all string formatting.
+- **Type annotations** on all function signatures.
+- **Shared contract awareness**: Compose, env schema, and docs should agree after cleanup.
+- **Logging** should stay consistent with the surrounding module conventions.

--- a/AGENT.md
+++ b/AGENT.md
@@ -2,6 +2,7 @@
 
 ## 1. Critical Rules (Must Follow)
 - **Security**: **NEVER** read `.env.secrets` or `.env.deploy.secrets`.
+- **NEVER** store temp files in the codebase. Use out/tmp for this purpose and clean up when done.
 - **Environment**: **ALWAYS** run scripts within the virtual environment.
   ```bash
   source .venv/bin/activate && python <script>
@@ -16,8 +17,13 @@
 - **Style**: Follow **PEP 8**. Use **f-strings** for formatting.
 - **Logging**: Use `logging` module at `DEBUG` level. Use prefixes: `[STORE]:`, `[COLLECTOR]:`, `[TRADER]:`.
 - **Error Handling**: Use `try-except` blocks. Fail gracefully; avoid complex fallback mechanisms unless strictly necessary for reliability.
-- **Bugs**: If bugs like uncaught exceptions are reported, we need to automatically add a test (pytest or UI) to make sure the error does not occur again.
-- **Arguments**: Avoid optional arguments (`arg=None`) unless strictly necessary to prevent ambiguity/bugs. Use dict only when necessary. Prioritize using data classes
+- **Bugs**: Follow the **bug-fix** skill (`.github/skills/bug-fix/SKILL.md`): hypothesis → failing test (must fail gate) → minimal fix → verify. Every bug fix requires a test that proves it.
+- **Arguments**: Avoid optional arguments (`arg=None`) unless strictly necessary to prevent ambiguity/bugs. Use object, dict and `Any` only when necessary. Prioritize using data classes. Do strict input validation on arguments. Use strict-typing.
+- **Dataclass-first**: Use dataclasses for internal data structures by default. `to_dict()` and `from_dict()` methods are permitted only at API/JSON/file boundaries and must be clearly labelled as these restricted utilities. We use JSONValue as type for these serializations and should only be used for the serialization purpose. Search for existing data classes before creating new ones. 
+- **Typing Anti-Pattern (Forbidden)**: Do **not** declare required inputs as optional and then guard inside the same function (e.g., `def f(x: Optional[str]): if not x or not isinstance(x, str): return ...`). Validate/normalize at the boundary, then pass a strict required type (e.g., `str`) internally.
+- **Boundary Typing Principle**: Normalize nullable/untyped input at API or adapter boundaries, then pass strict typed values internally. Core/public signatures should use explicit dataclasses/protocols and non-optional types when the value is required.
+- **Fallback code**: Use fallbacks wisely where they cover for transient events such as API calls and timeouts. In the other cases prioritize gracefull failing
+- **Docs maintenance**: When modifying a module, review the corresponding docs in `docs/<module>/` for: (1) missing documentation for new or changed behavior, (2) duplicate descriptions across files that should be consolidated, and (3) broken or incorrect internal links. Fix any issues found as part of the change. A doc should start with a section describing the main principles guarded by the code
 - **Cleanup**: Delete obsolete code immediately.
 - **Permissions**: You have permission to run tests without asking.
 
@@ -30,20 +36,32 @@
 - **Core Functionality**: Real-time market data collection, technical analysis (indicators), and trading strategy execution.
 
 ## 2. File Organization
+Do not store temporary files in the source code directory. Use out/ for this purpose
 - `src/common/`: Shared utilities and core logic. **Reuse code from here whenever possible.**
 - `debug/`: Verification and one-off scripts. **Do NOT pollute the root directory.**
-- `out/`: Temporary output files including PR reviews and test reports.
+- `out/`: Temporary output files including test reports.
+- `out/PR`: Temporary output files for  PR reports.
 - `logs/`: Application logs (`logs/app.log`).
-- `tests/pytests/`: Unit and integration tests.
-- `tests/UI/`: UI tests using playwright
-- `planning/`: Planning files. Planning file must have a checkable task overview and clear phase exit criteria. The first phase in a plan should always be optimizing the module we are going to change. See (`docs/CODE_PROMPTS.md`) section ## cleanup. Also check if docs must be merged or are obsolete.
+- `tests/pytests/`: Unit and integration tests.  Tests should start with test_<module>...
+- `tests/UI/`: UI tests using playwright. Tests should start with test_ui_<module>...
+- `planning/`: Planning files. Planning file must have a checkable task overview and clear phase exit criteria. The first phase in a plan should always be cleanup — follow the **module-cleanup** skill (`.github/skills/module-cleanup/SKILL.md`). Also check if docs must be merged or are obsolete. UI plans should show a mockup of the new design.
+- `archive/planning/`: Completed plans go here. When all tasks in a plan are done, rename with `_ARCHIVED` suffix and move to `archive/planning/`.
 - `docs/`: Documentation. Each major topic should have a doc. 
 
 ## 3. Workflows & Preferences
 ### User Preferences
 - **CSV Exports**: Use semicolon (`;`) delimiter and comma (`,`) for decimals (Excel-friendly).
-- **PR Reviews**: Return reports as raw markdown files (e.g., `Review.md`).
+- **PR Reviews**: Return reports as raw markdown files (e.g., `out/PR/Review.md`).
 
 ### Testing Context
 - **Tooling**: We use `pytest` for backend tests.
+- **Canonical runner**: Use `source .venv/bin/activate && python scripts/run_tests.py` for mixed backend + UI validation. This is the default repo runner because it manages boundary lint, backend tests, UI sharding, and the test server lifecycle consistently.
+- **Fail-fast CI / preflight**: When a known risky or recently fixed subset should run before the rest of the suite, pass a JSON array of selectors to `--priority-tests`. Example:
+  ```bash
+  source .venv/bin/activate && python scripts/run_tests.py --priority-tests='["tests/pytests/test_indicator_catalog.py","tests/UI/test_ui_indicator_catalog.py"]'
+  ```
+  The priority selectors run first and abort the suite immediately on failure; if they pass, the normal suite continues. Use this to front-load historically failing tests in CI without replacing full-suite coverage.
 - **Philosophy**: Tests are encouraged for all new logic.
+
+# App specific logic
+See `./AGENT_APP_SPECIFIC`

--- a/AGENT.md
+++ b/AGENT.md
@@ -2,66 +2,68 @@
 
 ## 1. Critical Rules (Must Follow)
 - **Security**: **NEVER** read `.env.secrets` or `.env.deploy.secrets`.
-- **NEVER** store temp files in the codebase. Use out/tmp for this purpose and clean up when done.
-- **Environment**: **ALWAYS** run scripts within the virtual environment.
+- **Temp files**: **NEVER** store scratch files in the codebase. Use `out/tmp` and clean up when done.
+- **Environment**: **ALWAYS** run Python tooling inside the virtual environment.
   ```bash
   source .venv/bin/activate && python <script>
   ```
-- **Server Startup**: Use the dedicated startup command to ensure proper logging.
-  ```bash
-  source .venv/bin/activate && python run.py
-  ```
+- **Source of truth**: Treat `docker/docker-compose.yml` and `scripts/deploy/env_schema.py` as authoritative for service shape and allowed deploy/runtime keys.
+- **Customization boundary**: Prefer deploy hooks and schema-driven config over hardcoded downstream-specific behavior in core deploy scripts.
 
 ## 2. Development Standards
+
 ### Code Quality
 - **Style**: Follow **PEP 8**. Use **f-strings** for formatting.
-- **Logging**: Use `logging` module at `DEBUG` level. Use prefixes: `[STORE]:`, `[COLLECTOR]:`, `[TRADER]:`.
-- **Error Handling**: Use `try-except` blocks. Fail gracefully; avoid complex fallback mechanisms unless strictly necessary for reliability.
-- **Bugs**: Follow the **bug-fix** skill (`.github/skills/bug-fix/SKILL.md`): hypothesis → failing test (must fail gate) → minimal fix → verify. Every bug fix requires a test that proves it.
-- **Arguments**: Avoid optional arguments (`arg=None`) unless strictly necessary to prevent ambiguity/bugs. Use object, dict and `Any` only when necessary. Prioritize using data classes. Do strict input validation on arguments. Use strict-typing.
-- **Dataclass-first**: Use dataclasses for internal data structures by default. `to_dict()` and `from_dict()` methods are permitted only at API/JSON/file boundaries and must be clearly labelled as these restricted utilities. We use JSONValue as type for these serializations and should only be used for the serialization purpose. Search for existing data classes before creating new ones. 
-- **Typing Anti-Pattern (Forbidden)**: Do **not** declare required inputs as optional and then guard inside the same function (e.g., `def f(x: Optional[str]): if not x or not isinstance(x, str): return ...`). Validate/normalize at the boundary, then pass a strict required type (e.g., `str`) internally.
-- **Boundary Typing Principle**: Normalize nullable/untyped input at API or adapter boundaries, then pass strict typed values internally. Core/public signatures should use explicit dataclasses/protocols and non-optional types when the value is required.
-- **Fallback code**: Use fallbacks wisely where they cover for transient events such as API calls and timeouts. In the other cases prioritize gracefull failing
-- **Docs maintenance**: When modifying a module, review the corresponding docs in `docs/<module>/` for: (1) missing documentation for new or changed behavior, (2) duplicate descriptions across files that should be consolidated, and (3) broken or incorrect internal links. Fix any issues found as part of the change. A doc should start with a section describing the main principles guarded by the code
-- **Cleanup**: Delete obsolete code immediately.
-- **Permissions**: You have permission to run tests without asking.
+- **Error handling**: Fail clearly. Use fallbacks only where they address real transient or platform-specific conditions.
+- **Bugs**: Follow the **bug-fix** skill (`.github/skills/bug-fix/SKILL.md`): hypothesis → failing test (must fail gate) → minimal fix → verify.
+- **Typing**: Normalize nullable or untyped input at boundaries, then pass strict required types internally.
+- **Reuse**: Search `scripts/deploy/`, existing tests, and deploy helpers before creating new abstractions.
+- **Docs maintenance**: When modifying deploy behavior, review the relevant docs in `docs/deploy/`, `README.md`, and any active planning file. Keep commands, env keys, and examples aligned with the code.
+- **Cleanup**: Delete obsolete code and stale documentation immediately.
+- **Permissions**: You have permission to run validation commands and tests without asking.
 
-# Project Context
+## 3. Project Context
 
-## 1. Project Overview
-**Stock Dashboard** is a Python web application for tracking and analyzing stock/crypto market data.
-- **Backend**: Flask + Socket.IO (threaded mode).
-- **Frontend**: HTML templates + Static Assets (JS/CSS).
-- **Core Functionality**: Real-time market data collection, technical analysis (indicators), and trading strategy execution.
+### Project Overview
+**Protected Container** is a deployment toolkit for running application payloads behind automatic HTTPS, with strict env-schema validation and parallel deploy paths for Ubuntu servers and Azure Container Instances.
 
-## 2. File Organization
-Do not store temporary files in the source code directory. Use out/ for this purpose
-- `src/common/`: Shared utilities and core logic. **Reuse code from here whenever possible.**
-- `debug/`: Verification and one-off scripts. **Do NOT pollute the root directory.**
-- `out/`: Temporary output files including test reports.
-- `out/PR`: Temporary output files for  PR reports.
-- `logs/`: Application logs (`logs/app.log`).
-- `tests/pytests/`: Unit and integration tests.  Tests should start with test_<module>...
-- `tests/UI/`: UI tests using playwright. Tests should start with test_ui_<module>...
-- `planning/`: Planning files. Planning file must have a checkable task overview and clear phase exit criteria. The first phase in a plan should always be cleanup — follow the **module-cleanup** skill (`.github/skills/module-cleanup/SKILL.md`). Also check if docs must be merged or are obsolete. UI plans should show a mockup of the new design.
-- `archive/planning/`: Completed plans go here. When all tasks in a plan are done, rename with `_ARCHIVED` suffix and move to `archive/planning/`.
-- `docs/`: Documentation. Each major topic should have a doc. 
+Core concerns in this repo:
+- Docker Compose as the service contract
+- centralized Caddy routing for Ubuntu hosts
+- Portainer-assisted or direct Compose Ubuntu deploys
+- Azure ACI deploy generation from Compose
+- schema-driven env/secrets handling
+- hook-based downstream customization
+- storage-manager integration through Compose labels
 
-## 3. Workflows & Preferences
-### User Preferences
-- **CSV Exports**: Use semicolon (`;`) delimiter and comma (`,`) for decimals (Excel-friendly).
-- **PR Reviews**: Return reports as raw markdown files (e.g., `out/PR/Review.md`).
+### File Organization
+Do not store temporary files in the source tree. Use `out/` for temporary artifacts.
 
-### Testing Context
-- **Tooling**: We use `pytest` for backend tests.
-- **Canonical runner**: Use `source .venv/bin/activate && python scripts/run_tests.py` for mixed backend + UI validation. This is the default repo runner because it manages boundary lint, backend tests, UI sharding, and the test server lifecycle consistently.
-- **Fail-fast CI / preflight**: When a known risky or recently fixed subset should run before the rest of the suite, pass a JSON array of selectors to `--priority-tests`. Example:
+- `scripts/deploy/`: Core deployment logic, helpers, env schema, and deploy utilities.
+- `docker/`: Compose files, Dockerfiles, startup scripts, proxy stack, and storage-manager assets.
+- `docs/deploy/`: Deployment contracts, how-to guides, and customization docs.
+- `tests/pytests/`: Python unit and integration tests.
+- `planning/`: Active planning files. Plans must have checkable tasks and explicit phase exit criteria. Phase 0 should always be cleanup.
+- `out/`: Temporary output files, including review artifacts under `out/PR/`.
+- `.github/agents/` and `.github/skills/`: Repo-specific Copilot workflow customizations.
+
+## 4. Workflows And Preferences
+
+### Validation Context
+- **Tooling**: We use `pytest` for Python tests.
+- **Common focused checks**:
   ```bash
-  source .venv/bin/activate && python scripts/run_tests.py --priority-tests='["tests/pytests/test_indicator_catalog.py","tests/UI/test_ui_indicator_catalog.py"]'
+  source .venv/bin/activate && pytest -q tests/pytests/test_<module>.py
+  source .venv/bin/activate && python3 scripts/deploy/validate_env.py
+  source .venv/bin/activate && python scripts/deploy/ubuntu_deploy.py --help
+  source .venv/bin/activate && python scripts/deploy/azure_deploy_container.py --help
+  docker compose -f docker/docker-compose.yml config
   ```
-  The priority selectors run first and abort the suite immediately on failure; if they pass, the normal suite continues. Use this to front-load historically failing tests in CI without replacing full-suite coverage.
-- **Philosophy**: Tests are encouraged for all new logic.
+- **CI baseline**: The GitHub Actions workflow currently runs `pytest` and Docker image build checks. Keep local validation aligned with the touched surface.
+- **Philosophy**: Prefer the narrowest executable check that can falsify the change before running broader validation.
 
-# App specific logic
-See `./AGENT_APP_SPECIFIC`
+### Reviews
+- **PR Reviews**: Return review artifacts as raw markdown files under `out/PR/`.
+
+## 5. App-Specific Logic
+See `./AGENT_APP_SPECIFIC.md`.

--- a/AGENT_APP_SPECIFIC.md
+++ b/AGENT_APP_SPECIFIC.md
@@ -1,0 +1,66 @@
+# Agent App Specific Instructions
+
+## 1. Product Boundary
+
+- This repository is a deployment toolkit first. Its core business logic is how application payloads are packaged, configured, routed, and deployed across local Docker, Ubuntu servers, and Azure.
+- `code-server` is the default example payload, not a hardcoded product requirement. Core deploy logic must stay reusable for downstream repos that swap in a different app.
+- When changing behavior, prefer strengthening shared deployment contracts over adding repo-specific special cases.
+
+## 2. Docker Compose Is The Source Of Truth
+
+- `docker/docker-compose.yml` and its target-specific overrides define the canonical service shape. Deployment code should derive behavior from Compose, not from duplicated constants.
+- Service roles must be inferred from Compose metadata such as `x-deploy-role`, not from hardcoded service names, ports, or legacy assumptions like `CODE_SERVER_PORT`.
+- Commands, ports, images, networks, and labels should be read from Compose or adjusted through hooks. Duplicating them in deploy scripts creates parity bugs.
+- Local-development bind mounts may exist in Compose, but deploy targets may normalize or ignore unsupported mounts. The deploy engine should translate Compose intent to the target platform rather than pretending all local mounts are portable.
+
+## 3. Runtime Config And Deploy Config Are Separate Domains
+
+- Runtime application config belongs in `.env` and `.env.secrets`.
+- Deployment-time infrastructure config belongs in `.env.deploy` and `.env.deploy.secrets`.
+- The schema in `scripts/deploy/env_schema.py` is authoritative. Unknown keys, implicit aliases, and silent compatibility shims are configuration bugs.
+- When adding a variable or secret, update the schema, the example env files, the docs, and tests together.
+- Secrets must stay out of Git history and out of logs. Prefer Key Vault, GitHub Actions secrets, or ignored dotenv secret files.
+
+## 4. Shared Ingress Architecture
+
+- On Ubuntu, the centralized Caddy proxy is the only public ingress and the only service that should bind host ports `80` and `443`.
+- Application stacks should join the external `caddy` network and should not publish their own public host ports for normal web traffic.
+- Domain routing is a first-class contract. `PUBLIC_DOMAIN`, `WEB_PORT`, and the upstream service/container name must stay aligned so Caddy registration remains deterministic.
+- Caddy registration should be automated and idempotent. Manual Caddyfile edits are a debugging fallback, not the normal workflow.
+
+## 5. Portainer Is A Control Plane, Not The Truth Source
+
+- Portainer can orchestrate Ubuntu deployments, but it must not become the authoritative definition of the stack.
+- The repo-owned Compose files and env files remain the source of truth for what gets deployed.
+- If Portainer is missing, stale, or uninitialized, deployment logic should fail clearly or use a controlled fallback. It should not invent a second deployment model with different behavior.
+
+## 6. Hooks Are The Customization Boundary
+
+- Repo-specific deployment behavior belongs in deployment hooks, not in hardcoded forks of the core deploy scripts.
+- `build_deploy_plan` is the preferred place to override images, commands, resources, and storage-registration behavior.
+- Hook-based customization should preserve upstream compatibility: extend the plan, do not bypass the shared contracts unless the target platform truly requires it.
+
+## 7. Storage Manager Rules Live In Compose Labels
+
+- Volume cleanup policy is declared by `storage-manager.<n>.*` Compose labels on the owning service.
+- Registration data should be derived from those labels, not duplicated in Python constants or out-of-band manual steps.
+- If `STORAGE_MANAGER_API_URL` is configured, Ubuntu deploy should register labels through the API. If the storage-manager service is in the same stack, same-stack discovery can be used as the default path.
+- Cleanup algorithms and their parameters must stay explicit in labels and API payloads. Hidden cleanup behavior is a business-logic bug.
+
+## 8. Security And Auth Boundaries
+
+- External TLS termination and edge authentication belong at the proxy layer.
+- Runtime containers should assume they are behind the configured ingress architecture instead of reimplementing overlapping edge concerns unless the docs explicitly require a second auth layer.
+- Azure runtime secret delivery should use Managed Identity plus Key Vault. Ubuntu runtime secret delivery should use synced env files mounted into the container runtime path.
+
+## 9. Cross-Target Parity Matters
+
+- Local Docker, Ubuntu deploy, and Azure deploy are different execution environments but should honor the same Compose-driven service intent wherever possible.
+- A change that only works in one deploy path because it hardcodes target-specific assumptions is usually a regression.
+- When a target has platform constraints, keep the constraint handling isolated in the renderer or deploy adapter and preserve the shared business contract above it.
+
+## 10. Change Discipline
+
+- When changing deployment logic, update the nearest docs in `docs/` and the relevant planning assumptions if they are no longer true.
+- Validate behavior with focused tests whenever the change affects Compose parsing, env resolution, hooks, routing, or deployment orchestration.
+- Delete obsolete deployment paths and stale assumptions quickly. This project depends on a small set of explicit contracts staying coherent.

--- a/planning/STORAGE_MANAGER.md
+++ b/planning/STORAGE_MANAGER.md
@@ -52,7 +52,7 @@ graph TB
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | Language | **Python** | Aligns with project conventions (PEP 8, pytest, logging prefixes). |
-| Framework | **Flask** (lightweight) | Consistent with the existing stock-dashboard backend. |
+| Framework | **Flask** (lightweight) | Consistent with the repo's Python-based deploy tooling and pytest workflow. |
 | Scheduling | **APScheduler** | In-process, no external cron dependency. |
 | Registration | **REST API + Docker compose labels** | API for runtime registration; labels for static/boot-time discovery via Docker socket. |
 | Storage | **SQLite** (single-file, in a volume) | Persists registrations across restarts; no external DB needed. |

--- a/planning/UBUNTU_SERVER_DEPLOYMENT.md
+++ b/planning/UBUNTU_SERVER_DEPLOYMENT.md
@@ -3,17 +3,16 @@
 This plan covers the work in this repo (`protected-container`) to support Ubuntu server as a
 first-class deployment target alongside Azure ACI.
 
-Stock-dashboard-specific work is tracked separately in
-`stock-dashboard/planning/UBUNTU_SERVER_DEPLOYMENT.md`.
+Downstream-repo-specific rollout work should be tracked in the downstream repo's own planning files.
+```
+app1.example.com {
+    reverse_proxy app1:{$WEB_PORT:-3000}
+}
 
----
-
-## Task Checklist
-
-- [x] **Phase 0** — Rename repo & review existing docs
-- [x] **Phase 1** — `ubuntu_start.sh` plain entrypoint
-- [x] **Phase 2** — `ubuntu_deploy.py` SSH deploy engine script
-- [x] **Phase 3** — Generic `build_push.sh` local build+push helper
+app2.example.com {
+    reverse_proxy app2:{$APP2_PORT:-4000}
+}
+```
 - [x] **Phase 4** — Multi-app Caddy routing (Caddyfile template)
 - [x] **Phase 5** — Documentation (`docs/deploy/UBUNTU_SERVER.md`)
 - [ ] **Phase 6** — Verification
@@ -176,12 +175,12 @@ stack runs without a Caddy sidecar:
 ```
 {$ACME_EMAIL:?required}
 
-dashboard.example.com {
-    reverse_proxy stock-dashboard:{$WEB_PORT:-3000}
+app1.example.com {
+    reverse_proxy app1:{$WEB_PORT:-3000}
 }
 
-trader.example.com {
-    reverse_proxy trader-app:{$TRADER_PORT:-4000}
+app2.example.com {
+    reverse_proxy app2:{$APP2_PORT:-4000}
 }
 ```
 

--- a/planning/cleanup-repo-instructions-and-stale-references.md
+++ b/planning/cleanup-repo-instructions-and-stale-references.md
@@ -1,0 +1,80 @@
+# Cleanup Repo Instructions And Stale References
+
+## Principles
+
+- Repo instructions, planning files, and issue templates must describe this deployment toolkit, not inherited behavior from another codebase.
+- `AGENT.md`, `AGENT_APP_SPECIFIC.md`, `.github/agents`, `.github/skills`, and planning/docs should tell one coherent story about Compose-driven deploys, env schema, hooks, shared Caddy routing, and Ubuntu/Azure targets.
+- Cleanup should remove contradictory or misleading references while preserving useful historical planning context where it is still relevant.
+- Validation for this cleanup is contract-focused: no stale cross-repo terminology should remain in the targeted files after the edit.
+
+## Checkable Task Overview
+
+- [ ] Phase 0: Audit stale copied references and define cleanup scope
+- [ ] Phase 1: Rewrite top-level agent instructions for this repo
+- [ ] Phase 2: Clean stale cross-repo references in planning and templates
+- [ ] Phase 3: Validate cleanup and prepare merge
+
+## Phase 0: Audit Cleanup Scope
+
+Identify remaining copied references from the stock-dashboard repo and confirm whether each one is stale, historical, or intentionally generic.
+
+Files expected to be reviewed:
+- `AGENT.md`
+- `planning/UBUNTU_SERVER_DEPLOYMENT.md`
+- `planning/STORAGE_MANAGER.md`
+- `.github/ISSUE_TEMPLATE/bug_report.md`
+
+### Exit Criteria
+
+- Target files are identified.
+- Cleanup scope is limited to stale or misleading cross-repo references.
+- Validation commands are chosen before editing.
+
+## Phase 1: Rewrite Top-Level Instructions
+
+Update `AGENT.md` so it matches this repo's actual structure and workflows.
+
+Expected outcomes:
+- Replace stock-dashboard project context with deployment-toolkit context.
+- Remove references to nonexistent runners or UI folders.
+- Keep the rules that still apply, especially env-secret handling, virtualenv usage, planning discipline, and deploy-centric validation.
+
+### Exit Criteria
+
+- `AGENT.md` reflects the current repo accurately.
+- Top-level instructions do not contradict `AGENT_APP_SPECIFIC.md` or the current `.github/agents` / `.github/skills` files.
+
+## Phase 2: Clean Planning And Template References
+
+Update stale wording in planning files and issue templates without changing the underlying implementation history.
+
+Expected outcomes:
+- Remove stock-dashboard-specific references that no longer belong in this repo.
+- Replace legacy comparisons with neutral or repo-specific wording.
+- Keep valid upstream/downstream planning context where it still helps explain decisions.
+
+### Exit Criteria
+
+- Target planning files and template text no longer contain stale copied references.
+- Historical intent is preserved where still relevant.
+
+## Phase 3: Validate Cleanup And Prepare Merge
+
+Validation commands:
+
+```bash
+rg -n "stock[- ]dashboard|STOCK_DASHBOARD|trade strategy|optimizer|watchlist|analyzer|trader|HistoricalDataStore|signal pipeline" AGENT.md .github planning docs tests scripts
+```
+
+Plus diagnostics checks on edited markdown files.
+
+If cleanup is complete:
+- commit the cleanup changes
+- push the branch
+- review merge readiness based on git state and validation results
+
+### Exit Criteria
+
+- The targeted stale-reference sweep returns no unexpected matches.
+- Edited files have no diagnostics.
+- Branch is ready for the merge step.

--- a/planning/cleanup-repo-instructions-and-stale-references.md
+++ b/planning/cleanup-repo-instructions-and-stale-references.md
@@ -9,10 +9,17 @@
 
 ## Checkable Task Overview
 
-- [ ] Phase 0: Audit stale copied references and define cleanup scope
-- [ ] Phase 1: Rewrite top-level agent instructions for this repo
-- [ ] Phase 2: Clean stale cross-repo references in planning and templates
-- [ ] Phase 3: Validate cleanup and prepare merge
+- [x] Phase 0: Audit stale copied references and define cleanup scope
+- [x] Phase 1: Rewrite top-level agent instructions for this repo
+- [x] Phase 2: Clean stale cross-repo references in planning and templates
+- [x] Phase 3: Validate cleanup and prepare merge
+
+## Completion Notes
+
+- `AGENT.md` was rewritten to describe this deployment toolkit rather than the copied stock-dashboard app.
+- Stale stock-dashboard wording was removed from the targeted planning files and issue template.
+- The final stale-reference sweep returned matches only inside this cleanup plan's own meta text and search command, which is acceptable.
+- This plan is complete and kept in `planning/` because the repo does not currently define a separate archive location or archived-plan naming convention.
 
 ## Phase 0: Audit Cleanup Scope
 
@@ -63,7 +70,7 @@ Expected outcomes:
 Validation commands:
 
 ```bash
-rg -n "stock[- ]dashboard|STOCK_DASHBOARD|trade strategy|optimizer|watchlist|analyzer|trader|HistoricalDataStore|signal pipeline" AGENT.md .github planning docs tests scripts
+grep -RInE "stock[- ]dashboard|STOCK_DASHBOARD|trade strategy|optimizer|watchlist|analyzer|trader|HistoricalDataStore|signal pipeline" AGENT.md .github planning docs tests scripts
 ```
 
 Plus diagnostics checks on edited markdown files.

--- a/scripts/deploy/portainer_helpers.py
+++ b/scripts/deploy/portainer_helpers.py
@@ -29,6 +29,17 @@ def _portainer_auth_headers(*, access_token: str) -> dict[str, str]:
     return {}
 
 
+def _format_portainer_api_error(payload: object) -> str:
+    if not isinstance(payload, dict):
+        return ""
+
+    message = str(payload.get("message") or "").strip()
+    details = str(payload.get("details") or "").strip()
+    if message and details and details != message:
+        return f"{message}: {details}"
+    return message or details
+
+
 def extract_ssh_hostname(host: str) -> str:
     return host.split("@", 1)[1] if "@" in host else host
 
@@ -54,6 +65,9 @@ def resolve_portainer_webhook_url_via_api(
     stacks_resp.raise_for_status()
     stacks_payload = stacks_resp.json()
     if not isinstance(stacks_payload, list):
+        error_text = _format_portainer_api_error(stacks_payload)
+        if error_text:
+            raise SystemExit(f"Portainer /api/stacks returned an unexpected payload: {error_text}")
         raise SystemExit("Unexpected Portainer /api/stacks response format")
 
     desired_name = stack_name.strip()
@@ -62,6 +76,9 @@ def resolve_portainer_webhook_url_via_api(
     endpoints_resp.raise_for_status()
     endpoints_payload = endpoints_resp.json()
     if not isinstance(endpoints_payload, list) or not endpoints_payload:
+        error_text = _format_portainer_api_error(endpoints_payload)
+        if error_text:
+            raise SystemExit(f"Portainer /api/endpoints returned an unexpected payload: {error_text}")
         raise SystemExit("No Portainer endpoints found")
 
     desired_endpoint = endpoint_id.strip()
@@ -179,6 +196,9 @@ def is_portainer_access_token_valid(
 
     payload = resp.json()
     if not isinstance(payload, list):
+        error_text = _format_portainer_api_error(payload)
+        if error_text:
+            raise SystemExit(f"Portainer /api/endpoints returned an unexpected payload: {error_text}")
         raise SystemExit("Unexpected Portainer /api/endpoints response format")
     return True
 

--- a/scripts/deploy/ubuntu_deploy.py
+++ b/scripts/deploy/ubuntu_deploy.py
@@ -115,6 +115,30 @@ def build_ssh_connectivity_cmd(*, host: str) -> list[str]:
     return build_ssh_cmd(host=host, remote_command="echo SSH_OK")
 
 
+def resolve_network_host_from_ssh_target(host: str) -> str:
+    raw_host = str(host).strip()
+    if not raw_host:
+        return ""
+
+    fallback_host = portainer_helpers.extract_ssh_hostname(raw_host).strip()
+    try:
+        result = subprocess.run(["ssh", "-G", raw_host], check=False, capture_output=True, text=True)
+    except OSError:
+        return fallback_host
+
+    if result.returncode != 0:
+        return fallback_host
+
+    for line in str(result.stdout or "").splitlines():
+        if not line.startswith("hostname "):
+            continue
+        resolved_host = line.split(None, 1)[1].strip()
+        if resolved_host:
+            return resolved_host
+
+    return fallback_host
+
+
 def build_docker_build_cmd(*, app_image: str, dockerfile: str, context_dir: str) -> list[str]:
     return ["docker", "build", "-f", dockerfile, "-t", app_image, context_dir]
 
@@ -129,6 +153,28 @@ def build_compose_config_cmd(*, compose_files: list[str]) -> list[str]:
         cmd.extend(["-f", compose_file])
     cmd.append("config")
     return cmd
+
+
+def build_remote_compose_deploy_cmd(*, remote_dir: Path, compose_files: list[str]) -> str:
+    quoted_remote_dir = shlex.quote(str(remote_dir))
+    compose_args = " ".join(f"-f {shlex.quote(str(compose_file))}" for compose_file in compose_files)
+    return (
+        f"cd {quoted_remote_dir} && "
+        f"export ENV_DIR={quoted_remote_dir} && "
+        "if docker compose version >/dev/null 2>&1; then "
+        f"docker compose {compose_args} pull && docker compose {compose_args} up -d --remove-orphans; "
+        "elif command -v docker-compose >/dev/null 2>&1; then "
+        f"docker-compose {compose_args} pull && docker-compose {compose_args} up -d --remove-orphans; "
+        "else "
+        "echo '[ubuntu-deploy] Docker Compose is not installed on the remote host. Install docker-compose-v2 or docker-compose and retry.' >&2; "
+        "exit 1; "
+        "fi"
+    )
+
+
+def _should_fallback_to_remote_compose(error_text: str) -> bool:
+    lowered = str(error_text).lower()
+    return "administrator initialization timeout" in lowered
 
 
 def render_compose_stack_content(*, repo_root: Path, compose_files: list[str]) -> str:
@@ -602,6 +648,7 @@ def main(argv: list[str] | None = None, repo_root_override: Path | None = None) 
         resolved_host = read_deploy_key(repo_root=repo_root, key=ENV_UBUNTU_SSH_HOST)
     if not resolved_host:
         raise SystemExit("Missing SSH host: provide --host, set UBUNTU_SSH_HOST, or add UBUNTU_SSH_HOST to .env.deploy")
+    resolved_portainer_host = resolve_network_host_from_ssh_target(resolved_host)
 
     resolved_remote_dir = str(args.remote_dir or "").strip()
     if not resolved_remote_dir:
@@ -825,6 +872,8 @@ def main(argv: list[str] | None = None, repo_root_override: Path | None = None) 
 
     log_step("Prepared deployment plan", icon="🧭")
     log_info(f"Target: {resolved_host}")
+    if resolved_portainer_host and resolved_portainer_host != portainer_helpers.extract_ssh_hostname(resolved_host):
+        log_info(f"Portainer API host: {resolved_portainer_host}")
     log_info(f"Remote dir: {remote_dir}")
     log_info(f"Compose files: {compose_files}")
     if storage_registrations:
@@ -934,25 +983,49 @@ def main(argv: list[str] | None = None, repo_root_override: Path | None = None) 
     else:
         log_info("Central proxy is already running.")
 
+    used_remote_compose_fallback = False
+
     if has_portainer_api_auth:
         log_step("Testing Portainer access token", icon="🔑")
-        if not portainer_helpers.is_portainer_access_token_valid(
-            host=resolved_host,
-            https_port=resolved_portainer_https_port,
-            insecure=resolved_portainer_webhook_insecure,
-            access_token=resolved_portainer_access_token,
-        ):
+        try:
+            token_valid = portainer_helpers.is_portainer_access_token_valid(
+                host=resolved_portainer_host,
+                https_port=resolved_portainer_https_port,
+                insecure=resolved_portainer_webhook_insecure,
+                access_token=resolved_portainer_access_token,
+            )
+        except SystemExit as exc:
+            error_text = str(exc)
+            if _should_fallback_to_remote_compose(error_text):
+                log_info(
+                    "Portainer is reachable but not initialized; falling back to direct Docker Compose deployment over SSH.",
+                    icon="⚠️",
+                )
+                used_remote_compose_fallback = True
+                token_valid = False
+            else:
+                raise
+        if not used_remote_compose_fallback and not token_valid:
             raise SystemExit(
                 "Portainer access token is invalid or expired. "
                 "Update PORTAINER_ACCESS_TOKEN in .env.deploy.secrets and retry. "
                 "If you intentionally want webhook-only deploys, remove PORTAINER_ACCESS_TOKEN."
             )
 
-    if has_portainer_api_auth:
+    if used_remote_compose_fallback:
+        log_step("Deploying stack directly with Docker Compose over SSH", icon="🐳")
+        _run(
+            build_ssh_cmd(
+                host=resolved_host,
+                remote_command=build_remote_compose_deploy_cmd(remote_dir=remote_dir, compose_files=compose_files),
+            ),
+            action="Failed direct Docker Compose deployment on the remote host",
+        )
+    elif has_portainer_api_auth:
         log_step("Deploying stack through Portainer API", icon="🌐")
         try:
             resolved_portainer_webhook_url = portainer_helpers.resolve_portainer_webhook_url_via_api(
-                host=resolved_host,
+                host=resolved_portainer_host,
                 https_port=resolved_portainer_https_port,
                 insecure=resolved_portainer_webhook_insecure,
                 stack_name=resolved_portainer_stack_name,
@@ -972,14 +1045,16 @@ def main(argv: list[str] | None = None, repo_root_override: Path | None = None) 
             else:
                 raise
 
-    if has_portainer_api_auth and not resolved_portainer_webhook_url:
+    if used_remote_compose_fallback:
+        log_step("Stack deployed directly over SSH; skipping Portainer webhook trigger", icon="✅")
+    elif has_portainer_api_auth and not resolved_portainer_webhook_url:
         log_step("Stack deployed via Portainer API; webhook token not returned, skipping webhook trigger", icon="✅")
     else:
         webhook_urls = (
             [resolved_portainer_webhook_url]
             if resolved_portainer_webhook_url
             else portainer_helpers.build_portainer_webhook_urls_from_token(
-                host=resolved_host,
+                host=resolved_portainer_host,
                 https_port=resolved_portainer_https_port,
                 webhook_token=resolved_portainer_token,
             )

--- a/scripts/deploy/ubuntu_deploy_proxy.sh
+++ b/scripts/deploy/ubuntu_deploy_proxy.sh
@@ -47,7 +47,14 @@ ssh "${UBUNTU_SSH_HOST}" "
   cd ${PROXY_DIR}
   export ACME_EMAIL='${ACME_EMAIL}'
   export PUBLIC_DOMAIN='${PUBLIC_DOMAIN}'
-  docker compose up -d
+  if docker compose version >/dev/null 2>&1; then
+    docker compose up -d
+  elif command -v docker-compose >/dev/null 2>&1; then
+    docker-compose up -d
+  else
+    echo '[proxy-deploy] ❌ Error: Docker Compose is not installed on the remote host. Install docker-compose-v2 or docker-compose and retry.' >&2
+    exit 1
+  fi
 "
 
 echo "[proxy-deploy] ✅ Central Caddy Proxy deployed successfully."

--- a/tests/pytests/test_ubuntu_deploy.py
+++ b/tests/pytests/test_ubuntu_deploy.py
@@ -2,9 +2,11 @@ from pathlib import Path
 
 from scripts.deploy.ubuntu_deploy import (
     _coerce_label_value,
+    _should_fallback_to_remote_compose,
     build_compose_config_cmd,
     build_docker_build_cmd,
     build_docker_push_cmd,
+    build_remote_compose_deploy_cmd,
     build_rsync_cmd,
     build_ssh_connectivity_cmd,
     build_ssh_cmd,
@@ -14,6 +16,7 @@ from scripts.deploy.ubuntu_deploy import (
     parse_boolish,
     prepare_stack_content_for_portainer,
     register_storage_manager_registrations,
+    resolve_network_host_from_ssh_target,
     rewrite_rendered_paths_for_remote,
     stack_has_service,
     read_deploy_key,
@@ -54,6 +57,19 @@ def test_build_compose_config_cmd_with_multiple_files():
     ]
 
 
+def test_build_remote_compose_deploy_cmd_contains_compose_variants_and_env_dir():
+    cmd = build_remote_compose_deploy_cmd(
+        remote_dir=Path("/home/ronny/containers/protected-container"),
+        compose_files=["docker/docker-compose.yml", "docker/docker-compose.ubuntu.yml"],
+    )
+
+    assert "cd /home/ronny/containers/protected-container" in cmd
+    assert "export ENV_DIR=/home/ronny/containers/protected-container" in cmd
+    assert "docker compose -f docker/docker-compose.yml -f docker/docker-compose.ubuntu.yml pull" in cmd
+    assert "docker compose -f docker/docker-compose.yml -f docker/docker-compose.ubuntu.yml up -d --remove-orphans" in cmd
+    assert "docker-compose -f docker/docker-compose.yml -f docker/docker-compose.ubuntu.yml up -d --remove-orphans" in cmd
+
+
 def test_build_docker_build_and_push_cmds():
     build_cmd = build_docker_build_cmd(
         app_image="ghcr.io/beejones/protected-container:latest",
@@ -81,6 +97,43 @@ def test_build_ssh_cmd_basic():
 def test_build_ssh_connectivity_cmd_basic():
     cmd = build_ssh_connectivity_cmd(host="user@host")
     assert cmd == ["ssh", "user@host", "echo SSH_OK"]
+
+
+def test_should_fallback_to_remote_compose_on_portainer_init_timeout():
+    assert _should_fallback_to_remote_compose(
+        "Portainer /api/endpoints returned an unexpected payload: Administrator initialization timeout"
+    ) is True
+    assert _should_fallback_to_remote_compose("Portainer access token was rejected") is False
+
+
+def test_resolve_network_host_from_ssh_target_uses_ssh_g(monkeypatch):
+    class DummyResult:
+        returncode = 0
+        stdout = "host ubuntu-server-01\nhostname 192.168.1.45\nuser ronny\n"
+
+    def fake_run(cmd, check, capture_output, text):
+        assert cmd == ["ssh", "-G", "ubuntu-server-01"]
+        assert check is False
+        assert capture_output is True
+        assert text is True
+        return DummyResult()
+
+    monkeypatch.setattr("scripts.deploy.ubuntu_deploy.subprocess.run", fake_run)
+
+    assert resolve_network_host_from_ssh_target("ubuntu-server-01") == "192.168.1.45"
+
+
+def test_resolve_network_host_from_ssh_target_falls_back_to_plain_hostname(monkeypatch):
+    class DummyResult:
+        returncode = 255
+        stdout = ""
+
+    def fake_run(cmd, check, capture_output, text):
+        return DummyResult()
+
+    monkeypatch.setattr("scripts.deploy.ubuntu_deploy.subprocess.run", fake_run)
+
+    assert resolve_network_host_from_ssh_target("ronny@ubuntu-server-01") == "ubuntu-server-01"
 
 
 def test_portainer_ensure_running_remote_cmd_contains_expected_steps():
@@ -174,6 +227,34 @@ def test_is_portainer_access_token_valid_false_on_401(monkeypatch):
         )
         is False
     )
+
+
+def test_is_portainer_access_token_valid_surfaces_portainer_message(monkeypatch):
+    class DummyResponse:
+        status_code = 303
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"message": "Administrator initialization timeout", "details": "Administrator initialization timeout"}
+
+    def fake_get(url, headers, verify, timeout):
+        return DummyResponse()
+
+    monkeypatch.setattr("scripts.deploy.portainer_helpers.requests.get", fake_get)
+
+    try:
+        is_portainer_access_token_valid(
+            host="ronny@192.168.1.45",
+            https_port=9943,
+            insecure=True,
+            access_token="token-123",
+        )
+    except SystemExit as exc:
+        assert "Administrator initialization timeout" in str(exc)
+    else:
+        raise AssertionError("Expected SystemExit")
 
 
 def test_read_deploy_secret_key_reads_token(tmp_path: Path):


### PR DESCRIPTION
# Review Report: Add-additional-AGENT-docs

## Problem Statement

Bring the repo back into alignment with its actual deployment-toolkit business logic after copied stock-dashboard instructions and stale planning/template references had drifted into the branch, while also fixing the Ubuntu deployment path so deploys still succeed when Portainer is reachable but not initialized.

## Summary Of Changed Files

### Deployment behavior
- `scripts/deploy/ubuntu_deploy.py`
  - resolves SSH aliases to real network hosts before Portainer HTTP calls
  - detects Portainer administrator-initialization timeout and falls back to direct Docker Compose over SSH
  - builds direct remote Compose deploy commands for the Ubuntu path
- `scripts/deploy/portainer_helpers.py`
  - surfaces Portainer API error payloads more clearly
- `scripts/deploy/ubuntu_deploy_proxy.sh`
  - supports `docker compose` and `docker-compose` on the remote Ubuntu host
- `tests/pytests/test_ubuntu_deploy.py`
  - adds focused coverage for SSH alias resolution, direct-compose fallback, and Portainer error handling

### Repo guidance and agent customization
- `AGENT.md`
- `AGENT_APP_SPECIFIC.md`
- `.github/agents/build-feature.agent.md`
- `.github/agents/cleanup-local-branches.agent.md`
- `.github/skills/bug-fix/SKILL.md`
- `.github/skills/deploy-readiness-check/SKILL.md`
- `.github/skills/deploy-rollout-adoption/SKILL.md`
- `.github/skills/module-cleanup/SKILL.md`

These files were rewritten or adjusted to describe this repo's actual contracts: Compose as source of truth, env schema as source of truth for allowed keys, hooks as customization boundary, shared Caddy ingress, Ubuntu/Azure parity, and deploy-focused validation.

### Planning and template cleanup
- `planning/cleanup-repo-instructions-and-stale-references.md`
- `planning/UBUNTU_SERVER_DEPLOYMENT.md`
- `planning/STORAGE_MANAGER.md`
- `.github/ISSUE_TEMPLATE/bug_report.md`

These changes remove stale stock-dashboard references while preserving valid planning context.

## Validation Results

Executed validations:
- `source .venv/bin/activate && pytest -q tests/pytests/test_ubuntu_deploy.py`
  - result: `36 passed`
- `bash -n scripts/deploy/ubuntu_deploy_proxy.sh`
  - result: passed
- `source .venv/bin/activate && python scripts/deploy/ubuntu_deploy.py`
  - result: succeeded; detected uninitialized Portainer and completed deployment via direct Docker Compose fallback over SSH; Caddy registration verified
- stale-reference sweep across `AGENT.md`, `.github`, `planning`, `docs`, `tests`, and `scripts`
  - result: only the cleanup plan's own meta text still contains the search terms, which is expected
- diagnostics checks on edited markdown/template files
  - result: no errors found

## Docs Updated

Updated guidance and planning surfaces:
- `AGENT.md`
- `AGENT_APP_SPECIFIC.md`
- `.github/agents/build-feature.agent.md`
- `.github/skills/bug-fix/SKILL.md`
- `.github/skills/deploy-readiness-check/SKILL.md`
- `.github/skills/deploy-rollout-adoption/SKILL.md`
- `.github/skills/module-cleanup/SKILL.md`
- `planning/cleanup-repo-instructions-and-stale-references.md`
- `planning/UBUNTU_SERVER_DEPLOYMENT.md`
- `planning/STORAGE_MANAGER.md`
- `.github/ISSUE_TEMPLATE/bug_report.md`

## Residual Risks

- Portainer on the Ubuntu host is still uninitialized. Deploys now succeed through the direct Compose fallback, but Portainer-based webhook/API workflows will continue to report administrator-initialization errors until the instance is initialized.
- The remote Ubuntu build path still emits a warning that Compose is configured to use Bake while `buildx` is not installed. This did not block deployment, but it remains an environment-level optimization gap rather than a code defect.
- PR creation and merge still depend on GitHub-side checks succeeding after the branch is published.
