### PR TITLE
fix: protect auto-registered caddy routes

### DIFF
--- a/docs/deploy/SHARED_CADDY_ROUTING.md
+++ b/docs/deploy/SHARED_CADDY_ROUTING.md
@@ -1,5 +1,9 @@
 # Shared Caddy Routing 
 
+## Principles
+
+All public routes registered through the centralized Ubuntu Caddy proxy must inherit the same Caddy access gate before traffic is forwarded to an app container. Registration should be deterministic, idempotent, and safe to rerun: missing routes are appended, and stale unprotected routes are repaired instead of being silently treated as healthy.
+
 This guide explains how other projects deployed on the same Ubuntu server can register with the centralized Caddy proxy for automatic HTTPS routing — without needing their own sidecar proxies.
 
 ## How it works
@@ -12,6 +16,8 @@ Registration is **fully automated** by the `ubuntu_deploy.py` script.  All you n
 1. Prepare your project's `docker-compose.yml` (network + container name).
 2. Set the right env vars in `.env.deploy`.
 3. Run `ubuntu_deploy.py` — the Caddyfile is updated and Caddy reloaded for you.
+
+The generated site block includes the centralized proxy `basic_auth` guard using the existing `BASIC_AUTH_USER` and `BASIC_AUTH_HASH` placeholders. App-specific auth such as session login or API keys remains separate defense-in-depth behind that Caddy boundary.
 
 ## Step-by-step
 
@@ -67,7 +73,8 @@ The deploy script automatically:
 
 1. Reads the proxy Caddyfile on the remote host via SSH.
 2. Checks whether a site block for `PUBLIC_DOMAIN` already exists (idempotent).
-3. If missing, appends a site block with `reverse_proxy <service>:<port>`.
+3. If missing, appends a protected site block with `basic_auth` plus `reverse_proxy <service>:<port>`.
+4. If an existing domain block is present but unprotected, rewrites it with the standard `basic_auth` guard.
 4. Restarts the `central-proxy` container and validates the config.
 
 No manual SSH or Caddyfile editing required.
@@ -87,8 +94,23 @@ On the server, edit the Caddyfile (typically at `~/containers/protected-containe
 myapp.example.com {
     tls {$ACME_EMAIL}
     header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+
+  basic_auth /* {
+    {$BASIC_AUTH_USER} {$BASIC_AUTH_HASH}
+  }
+
     reverse_proxy my-app-production:8080
 }
+```
+
+### Safe verification
+
+```bash
+# Unauthenticated requests must be blocked by Caddy.
+curl -I https://myapp.example.com
+
+# Authenticated requests may then reach the app, which can still apply its own login/API auth.
+curl -I -u "$BASIC_AUTH_USER:<your-known-password>" https://myapp.example.com
 ```
 
 ### Reload Caddy

--- a/scripts/deploy/caddy_register.py
+++ b/scripts/deploy/caddy_register.py
@@ -36,6 +36,11 @@ SITE_BLOCK_TEMPLATE = """\
     tls {{$ACME_EMAIL}}
     encode gzip
     header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+
+    basic_auth /* {{
+        {{$BASIC_AUTH_USER}} {{$BASIC_AUTH_HASH}}
+    }}
+
     reverse_proxy {service}:{port}
 }}
 """
@@ -105,6 +110,102 @@ def _result_text(result: subprocess.CompletedProcess) -> str:
     return stderr or stdout
 
 
+def _find_site_block(caddyfile_text: str, site_label: str) -> str | None:
+    """Return the full site block for *site_label* when present."""
+    header_pattern = re.compile(
+        r"^(?!\s*#)\s*" + re.escape(site_label) + r"\s*\{\s*$"
+    )
+    lines = caddyfile_text.splitlines(keepends=True)
+    block_lines: list[str] = []
+    depth = 0
+    in_block = False
+
+    for line in lines:
+        normalized_line = line.rstrip("\r\n")
+        stripped_line = normalized_line.strip()
+
+        if not in_block:
+            if not header_pattern.match(normalized_line):
+                continue
+            in_block = True
+            depth = 1
+            block_lines.append(line)
+            continue
+
+        block_lines.append(line)
+        if stripped_line == "}":
+            depth -= 1
+            if depth == 0:
+                return "".join(block_lines)
+            continue
+
+        if stripped_line.endswith("{") and not stripped_line.startswith("#"):
+            depth += 1
+
+    return None
+
+
+def _site_block_has_basic_auth(site_block: str) -> bool:
+    """Return True when *site_block* contains a live basic_auth directive."""
+    pattern = re.compile(r"^(?!\s*#)\s*basic_auth\b", re.MULTILINE)
+    return bool(pattern.search(site_block))
+
+
+def _write_remote_caddyfile(*, ssh_host: str, caddyfile_path: str, content: str, append: bool) -> None:
+    """Write *content* to the remote Caddyfile, appending or replacing it."""
+    tee_flag = "-a " if append else ""
+    write_cmd = f"tee {tee_flag}{shlex.quote(caddyfile_path)} > /dev/null"
+    full = [
+        "ssh",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        ssh_host,
+        write_cmd,
+    ]
+    try:
+        subprocess.run(full, input=content, text=True, capture_output=True, check=True)
+    except subprocess.CalledProcessError as exc:
+        detail = str(exc.stderr or "").strip() or str(exc.stdout or "").strip()
+        action = "append to" if append else "rewrite"
+        raise RuntimeError(
+            f"Failed to {action} Caddyfile on {ssh_host}: {detail}"
+        )
+
+
+def _render_site_block(*, domain: str, service: str, port: str) -> str:
+    """Render a protected site block for *domain*."""
+    return SITE_BLOCK_TEMPLATE.format(domain=domain, service=service, port=port)
+
+
+def _restart_and_validate_caddy(*, ssh_host: str, caddy_container: str) -> None:
+    """Restart the Caddy container and validate its active config."""
+    logger.info("%s Restarting %s to pick up config", LOG_PREFIX, caddy_container)
+    restart_result = _ssh_run(
+        ssh_host,
+        f"docker restart {shlex.quote(caddy_container)}",
+        check=False,
+    )
+    if restart_result.returncode != 0:
+        detail = _result_text(restart_result)
+        raise RuntimeError(
+            f"Failed to restart {caddy_container} on {ssh_host}: {detail}"
+        )
+
+    validate_cmd = (
+        f"sleep 3 && docker exec {shlex.quote(caddy_container)} "
+        f"caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile"
+    )
+    validate_result = _ssh_run(ssh_host, validate_cmd, check=False)
+    if validate_result.returncode != 0:
+        detail = _result_text(validate_result)
+        raise RuntimeError(
+            "Caddy registration appended the route but config validation failed: "
+            f"{detail}. Check remote logs with: docker logs {caddy_container}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -139,21 +240,65 @@ def ensure_caddy_registration(
         return False
 
     caddyfile_text = result.stdout
+    expected_block = _render_site_block(domain=domain, service=service, port=port)
+    existing_domain_block = _find_site_block(caddyfile_text, domain)
 
     # 2. Already registered?  ────────────────────────────────────────────
-    if _domain_present(caddyfile_text, domain):
-        logger.info("%s %s already registered", LOG_PREFIX, domain)
-        return False
+    if existing_domain_block is not None:
+        if _site_block_has_basic_auth(existing_domain_block):
+            logger.info("%s %s already registered", LOG_PREFIX, domain)
+            return False
+
+        logger.warning(
+            "%s %s has an unprotected Caddy route; rewriting it with basic_auth.",
+            LOG_PREFIX,
+            domain,
+        )
+        updated_caddyfile_text = caddyfile_text.replace(existing_domain_block, expected_block, 1)
+
+        if dry_run:
+            logger.info("%s [dry-run] Would rewrite unprotected route for %s", LOG_PREFIX, domain)
+            logger.debug("%s [dry-run] Rewritten block:\n%s", LOG_PREFIX, expected_block)
+            return True
+
+        _write_remote_caddyfile(
+            ssh_host=ssh_host,
+            caddyfile_path=caddyfile_path,
+            content=updated_caddyfile_text,
+            append=False,
+        )
+
+        result2 = _ssh_run(ssh_host, f"cat {shlex.quote(caddyfile_path)}")
+        updated_domain_block = _find_site_block(str(result2.stdout or ""), domain)
+        if updated_domain_block is None:
+            raise RuntimeError(
+                f"Rewrote Caddy block for {domain} but it was not found on re-read"
+            )
+        if not _site_block_has_basic_auth(updated_domain_block):
+            raise RuntimeError(
+                f"Rewrote Caddy block for {domain} but it is still missing basic_auth"
+            )
+
+        caddyfile_text = str(result2.stdout or "")
+        _restart_and_validate_caddy(ssh_host=ssh_host, caddy_container=caddy_container)
+        logger.info("%s Registered %s -> %s:%s", LOG_PREFIX, domain, service, port)
+        return True
 
     # Special case: the base Caddyfile may already define {$PUBLIC_DOMAIN}.
     # If that placeholder resolves to this domain in the running proxy
     # container, skip appending a literal duplicate site block.
-    if _public_domain_placeholder_present(caddyfile_text):
+    placeholder_block = _find_site_block(caddyfile_text, "{$PUBLIC_DOMAIN}")
+
+    if placeholder_block is not None:
         resolved_public_domain = _remote_public_domain(
             ssh_host=ssh_host,
             caddy_container=caddy_container,
         )
         if resolved_public_domain and resolved_public_domain == domain:
+            if not _site_block_has_basic_auth(placeholder_block):
+                raise RuntimeError(
+                    f"{domain} is covered by {{$PUBLIC_DOMAIN}} but the placeholder route is missing basic_auth"
+                )
             logger.info(
                 "%s %s already covered by {$PUBLIC_DOMAIN} placeholder",
                 LOG_PREFIX,
@@ -162,7 +307,7 @@ def ensure_caddy_registration(
             return False
 
     # 3. Build the site block  ───────────────────────────────────────────
-    block = SITE_BLOCK_TEMPLATE.format(domain=domain, service=service, port=port)
+    block = expected_block
 
     if dry_run:
         logger.info("%s [dry-run] Would append to %s", LOG_PREFIX, caddyfile_path)
@@ -170,51 +315,27 @@ def ensure_caddy_registration(
         return True
 
     # 4. Append to host Caddyfile  ──────────────────────────────────────
-    append_cmd = f"tee -a {shlex.quote(caddyfile_path)} > /dev/null"
-    full = [
-        "ssh", "-o", "BatchMode=yes", "-o", "StrictHostKeyChecking=accept-new",
-        ssh_host, append_cmd,
-    ]
-    try:
-        subprocess.run(full, input=block, text=True, capture_output=True, check=True)
-    except subprocess.CalledProcessError as exc:
-        detail = str(exc.stderr or "").strip() or str(exc.stdout or "").strip()
-        raise RuntimeError(
-            f"Failed to append Caddy block on {ssh_host}: {detail}"
-        )
+    _write_remote_caddyfile(
+        ssh_host=ssh_host,
+        caddyfile_path=caddyfile_path,
+        content=block,
+        append=True,
+    )
 
     # 5. Verify the write  ──────────────────────────────────────────────
     result2 = _ssh_run(ssh_host, f"cat {shlex.quote(caddyfile_path)}")
-    if not _domain_present(result2.stdout, domain):
+    updated_domain_block = _find_site_block(str(result2.stdout or ""), domain)
+    if updated_domain_block is None:
         raise RuntimeError(
             f"Appended Caddy block for {domain} but it was not found on re-read"
         )
+    if not _site_block_has_basic_auth(updated_domain_block):
+        raise RuntimeError(
+            f"Appended Caddy block for {domain} but it is missing basic_auth"
+        )
 
     # 6. Restart Caddy to pick up bind-mount changes & obtain cert  ─────
-    logger.info("%s Restarting %s to pick up config", LOG_PREFIX, caddy_container)
-    restart_result = _ssh_run(
-        ssh_host,
-        f"docker restart {shlex.quote(caddy_container)}",
-        check=False,
-    )
-    if restart_result.returncode != 0:
-        detail = _result_text(restart_result)
-        raise RuntimeError(
-            f"Failed to restart {caddy_container} on {ssh_host}: {detail}"
-        )
-
-    # Brief wait for Caddy to boot, then validate config inside container.
-    validate_cmd = (
-        f"sleep 3 && docker exec {shlex.quote(caddy_container)} "
-        f"caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile"
-    )
-    validate_result = _ssh_run(ssh_host, validate_cmd, check=False)
-    if validate_result.returncode != 0:
-        detail = _result_text(validate_result)
-        raise RuntimeError(
-            "Caddy registration appended the route but config validation failed: "
-            f"{detail}. Check remote logs with: docker logs {caddy_container}"
-        )
+    _restart_and_validate_caddy(ssh_host=ssh_host, caddy_container=caddy_container)
 
     logger.info("%s Registered %s -> %s:%s", LOG_PREFIX, domain, service, port)
     return True
@@ -230,24 +351,26 @@ def is_domain_registered(
     """Return True when *domain* is covered by the remote Caddy config.
 
     Coverage is satisfied when either:
-    - a literal site block exists for ``domain``, or
+    - a literal site block exists for ``domain`` and includes ``basic_auth``, or
     - a ``{$PUBLIC_DOMAIN}`` site block exists and resolves to ``domain``
-      in the running Caddy container environment.
+      in the running Caddy container environment and includes ``basic_auth``.
     """
     result = _ssh_run(ssh_host, f"cat {shlex.quote(caddyfile_path)}", check=False)
     if result.returncode != 0:
         return False
 
     caddyfile_text = str(result.stdout or "")
-    if _domain_present(caddyfile_text, domain):
-        return True
+    domain_block = _find_site_block(caddyfile_text, domain)
+    if domain_block is not None:
+        return _site_block_has_basic_auth(domain_block)
 
-    if _public_domain_placeholder_present(caddyfile_text):
+    placeholder_block = _find_site_block(caddyfile_text, "{$PUBLIC_DOMAIN}")
+    if placeholder_block is not None:
         resolved_public_domain = _remote_public_domain(
             ssh_host=ssh_host,
             caddy_container=caddy_container,
         )
         if resolved_public_domain and resolved_public_domain == domain:
-            return True
+            return _site_block_has_basic_auth(placeholder_block)
 
     return False

--- a/tests/pytests/test_caddy_register.py
+++ b/tests/pytests/test_caddy_register.py
@@ -34,12 +34,31 @@ def test_site_block_template_formats_expected_fields() -> None:
     assert "encode gzip" in block
 
 
+def test_site_block_template_includes_basic_auth_placeholders() -> None:
+    block = caddy_register.SITE_BLOCK_TEMPLATE.format(
+        domain="example.com",
+        service="my-service",
+        port="8080",
+    )
+
+    assert "basic_auth /* {" in block
+    assert "{$BASIC_AUTH_USER} {$BASIC_AUTH_HASH}" in block
+
+
 def test_ensure_caddy_registration_skips_when_already_present(monkeypatch) -> None:
     calls: list[str] = []
+    protected_block = """
+example.com {
+    basic_auth /* {
+        {$BASIC_AUTH_USER} {$BASIC_AUTH_HASH}
+    }
+    reverse_proxy app:8080
+}
+"""
 
     def fake_ssh_run(host: str, cmd: str, **_: object) -> subprocess.CompletedProcess:
         calls.append(cmd)
-        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="example.com {\n}\n", stderr="")
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout=protected_block, stderr="")
 
     monkeypatch.setattr(caddy_register, "_ssh_run", fake_ssh_run)
 
@@ -68,8 +87,9 @@ def test_ensure_caddy_registration_appends_and_restarts(monkeypatch) -> None:
         assert text is True
         assert capture_output is True
         assert check is True
-        append_calls.append(" ".join(full))
-        if input:
+        command_text = full[-1]
+        append_calls.append(command_text)
+        if input is not None and command_text.startswith("tee -a "):
             state["caddyfile"] += input
         return subprocess.CompletedProcess(args=full, returncode=0, stdout="", stderr="")
 
@@ -86,8 +106,60 @@ def test_ensure_caddy_registration_appends_and_restarts(monkeypatch) -> None:
 
     assert out is True
     assert "example.com {" in state["caddyfile"]
+    assert "basic_auth /* {" in state["caddyfile"]
+    assert "{$BASIC_AUTH_USER} {$BASIC_AUTH_HASH}" in state["caddyfile"]
     assert "reverse_proxy my-service:8080" in state["caddyfile"]
-    assert len(append_calls) == 1
+    assert append_calls == ["tee -a /opt/proxy/Caddyfile > /dev/null"]
+
+
+def test_ensure_caddy_registration_repairs_existing_unprotected_route(monkeypatch) -> None:
+    state = {
+        "caddyfile": """
+example.com {
+    reverse_proxy my-service:8080
+}
+"""
+    }
+
+    def fake_ssh_run(host: str, cmd: str, **_: object) -> subprocess.CompletedProcess:
+        if cmd.startswith("cat "):
+            return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout=state["caddyfile"], stderr="")
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="", stderr="")
+
+    def fake_subprocess_run(
+        full: list[str],
+        input: str | None = None,
+        text: bool = True,
+        capture_output: bool = True,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess:
+        assert text is True
+        assert capture_output is True
+        assert check is True
+        command_text = full[-1]
+        if input is not None:
+            if command_text.startswith("tee -a "):
+                state["caddyfile"] += input
+            else:
+                state["caddyfile"] = input
+        return subprocess.CompletedProcess(args=full, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(caddy_register, "_ssh_run", fake_ssh_run)
+    monkeypatch.setattr(caddy_register.subprocess, "run", fake_subprocess_run)
+
+    out = caddy_register.ensure_caddy_registration(
+        ssh_host="user@host",
+        domain="example.com",
+        service="my-service",
+        port="8080",
+        caddyfile_path="/opt/proxy/Caddyfile",
+    )
+
+    assert out is True
+    assert state["caddyfile"].count("example.com {") == 1
+    assert "basic_auth /* {" in state["caddyfile"]
+    assert "{$BASIC_AUTH_USER} {$BASIC_AUTH_HASH}" in state["caddyfile"]
+    assert "reverse_proxy my-service:8080" in state["caddyfile"]
 
 
 def test_ensure_caddy_registration_raises_runtime_error_on_validate_failure(monkeypatch) -> None:
@@ -127,6 +199,9 @@ def test_ensure_caddy_registration_skips_when_public_domain_placeholder_matches(
     calls: list[str] = []
     caddyfile_text = """
 {$PUBLIC_DOMAIN} {
+    basic_auth /* {
+        {$BASIC_AUTH_USER} {$BASIC_AUTH_HASH}
+    }
     reverse_proxy protected-container:8080
 }
 """
@@ -151,3 +226,26 @@ def test_ensure_caddy_registration_skips_when_public_domain_placeholder_matches(
 
     assert out is False
     assert any("docker inspect" in cmd for cmd in calls)
+
+
+def test_is_domain_registered_returns_false_for_unprotected_site_block(monkeypatch) -> None:
+    caddyfile_text = """
+example.com {
+    reverse_proxy my-service:8080
+}
+"""
+
+    def fake_ssh_run(host: str, cmd: str, **_: object) -> subprocess.CompletedProcess:
+        if cmd.startswith("cat "):
+            return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout=caddyfile_text, stderr="")
+        return subprocess.CompletedProcess(args=["ssh"], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(caddy_register, "_ssh_run", fake_ssh_run)
+
+    out = caddy_register.is_domain_registered(
+        ssh_host="user@host",
+        domain="example.com",
+        caddyfile_path="/opt/proxy/Caddyfile",
+    )
+
+    assert out is False


### PR DESCRIPTION
## Summary
- add the central proxy basic_auth guard to auto-registered Ubuntu Caddy routes
- treat unprotected existing domain blocks as broken and rewrite them instead of accepting them as healthy
- document the protected shared-routing contract and cover the regression with unit tests

## Validation
- python -m pytest tests/pytests/test_caddy_register.py -x -v
- python -m pytest tests/pytests/test_ubuntu_deploy.py -x -v