### PR TITLE
feat: add deploy log hook settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Common hook uses:
 
 - Allowing additional runtime keys beyond the upstream schema
 - Translating legacy deploy keys (e.g. `GHCR_IMAGE` → `APP_IMAGE`)
+- Customizing deploy log location or disabling deploy-log version bumps
 - Post-processing the rendered ACI YAML / Caddyfile (e.g. injecting additional reverse-proxy routes)
 
 #### 4) Ensure CI checks out submodules

--- a/docs/deploy/HOOKS.md
+++ b/docs/deploy/HOOKS.md
@@ -54,8 +54,10 @@ Create a Python module that exports a `get_hooks()` function returning an object
 ### Example `deploy_customizations.py`
 
 ```python
-import os
+from pathlib import Path
+
 from scripts.deploy.deploy_hooks import DeployContext, DeployPlan
+from scripts.deploy.deploy_log import DeployLogSettings
 
 class MyHooks:
     def pre_validate_env(self, ctx: DeployContext) -> None:
@@ -76,6 +78,11 @@ class MyHooks:
     def post_render_yaml(self, ctx: DeployContext, plan: DeployPlan, yaml_text: str) -> str:
         """Called after YAML generation. Return modified YAML."""
         return yaml_text + "\n# Patched by custom hook"
+
+    def configure_deploy_log(self, ctx: DeployContext, plan: DeployPlan, settings: DeployLogSettings) -> None:
+        """Called before ubuntu_deploy.py writes the deploy tracking CSV."""
+        settings.versioning_enabled = False
+        settings.csv_path = Path("out/custom/deploy_log.csv")
 
 def get_hooks():
     return MyHooks()
@@ -119,6 +126,15 @@ For `ubuntu_deploy.py`, `deploy_result` includes:
 - `storage_registration_count`
 - `storage_manager_api_url`
 - `default_storage_registration_enabled`
+
+### `configure_deploy_log(ctx, plan, settings)`
+- **Summary**: Before `ubuntu_deploy.py` writes `deploy_log.csv`.
+- **Use for**: Customizing where deploy tracking is written and whether deploy tracking bumps `APP_VERSION`.
+
+The `settings` object is mutable:
+
+- `settings.csv_path` (`Path`): CSV path to write. Relative paths are resolved from `ctx.repo_root`.
+- `settings.versioning_enabled` (`bool`, default `True`): when `False`, deploy rows still record the current `APP_VERSION`, but successful `production` and `swap` deploys do not increment or write `APP_VERSION` back to `.env`.
 
 ### `on_error(ctx, exc)`
 - **Summary**: If an exception occurs during the deployment lifecycle.

--- a/docs/deploy/STAGING.md
+++ b/docs/deploy/STAGING.md
@@ -96,6 +96,7 @@ Every deploy writes a row to `out/deploy/deploy_log.csv`. The latest record appe
 |--------|---------|
 | `timestamp` | `2026-05-18T14:30:00Z` |
 | `git_ref` | Full 40-char SHA |
+| `local_branch` | Checked-out deploy branch |
 | `version` | `1.2.3` from `APP_VERSION` |
 | `target` | `staging` / `production` / `swap` |
 | `stack_name` | Portainer stack name |

--- a/planning/deploy-tracking-and-staging.md
+++ b/planning/deploy-tracking-and-staging.md
@@ -61,10 +61,11 @@
 - [x] Add `APP_VERSION=0.1.0` to `.env` (runtime config, read at deploy time)
 - [x] Add `APP_VERSION` to `env_schema.py` RUNTIME_SCHEMA (optional, default `0.0.0`)
 - [x] Create `scripts/deploy/deploy_log.py` with:
-  - `append_deploy_record(repo_root, git_ref, version, target, stack_name, domain, image, status)` → writes newest row below the header
-  - CSV columns: `timestamp,git_ref,version,target,stack_name,domain,image,status`
+  - `append_deploy_record(...)` / `append_deploy_record_with_settings(...)` → writes newest row below the header
+  - CSV columns: `timestamp,git_ref,local_branch,version,target,stack_name,domain,image,status`
   - Auto-creates `out/deploy/` directory if missing
   - `git_ref` = full 40-char SHA from `git rev-parse HEAD`
+  - `local_branch` = checked-out deploy branch, with legacy rows backfilled as `main`
   - `version` = read from `.env` key `APP_VERSION`
   - After successful **production** deploy: auto-increment patch in `.env` (`1.2.3` → `1.2.4`) so next deploy gets a new version
   - Staging and swap deploys: log current version but do NOT increment
@@ -234,3 +235,4 @@ After swap:
 - [x] Tests for stop/start lifecycle logic
 - [x] Latest `out/deploy/deploy_log.csv` record is written directly below the header
 - [x] Deploy log includes APP_VERSION in the `version` column for staging, production, and swap records
+- [x] Deploy log includes the checked-out branch in the `local_branch` column

--- a/scripts/deploy/deploy_hooks.py
+++ b/scripts/deploy/deploy_hooks.py
@@ -13,7 +13,13 @@ try:
 except ImportError:
     from env_schema import VarsEnum
 
-from typing import Any, Protocol, runtime_checkable, MutableMapping
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable, MutableMapping
+
+if TYPE_CHECKING:
+    try:
+        from scripts.deploy.deploy_log import DeployLogSettings
+    except ImportError:
+        from deploy_log import DeployLogSettings
 
 logger = logging.getLogger("deploy_hooks")
 
@@ -86,6 +92,7 @@ class DeployHooksProtocol(Protocol):
     def post_render_yaml(self, ctx: DeployContext, plan: DeployPlan, yaml_text: str) -> str: ...
     def pre_az_apply(self, ctx: DeployContext, plan: DeployPlan, yaml_path: Path) -> None: ...
     def post_deploy(self, ctx: DeployContext, plan: DeployPlan, deploy_result: Any) -> None: ...
+    def configure_deploy_log(self, ctx: DeployContext, plan: DeployPlan, settings: DeployLogSettings) -> None: ...
     def on_error(self, ctx: DeployContext, exc: Exception) -> None: ...
 
 class DeployHooks:

--- a/scripts/deploy/deploy_log.py
+++ b/scripts/deploy/deploy_log.py
@@ -1,7 +1,8 @@
 """Deploy tracking CSV logger.
 
 Writes a row to `out/deploy/deploy_log.csv` after each deploy, recording
-the git ref, version, target environment, stack name, domain, image, and status.
+the git ref, local branch, version, target environment, stack name, domain,
+image, and status.
 Newest records are stored directly under the CSV header.
 
 After a successful **production** deploy, auto-increments the patch component
@@ -15,6 +16,7 @@ from __future__ import annotations
 import csv
 import re
 import subprocess
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -22,6 +24,18 @@ from dotenv import dotenv_values
 
 
 CSV_COLUMNS = [
+    "timestamp",
+    "git_ref",
+    "local_branch",
+    "version",
+    "target",
+    "stack_name",
+    "domain",
+    "image",
+    "status",
+]
+
+LEGACY_CSV_COLUMNS = [
     "timestamp",
     "git_ref",
     "version",
@@ -33,13 +47,23 @@ CSV_COLUMNS = [
 ]
 
 _SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+_GIT_REF_COLUMN = CSV_COLUMNS.index("git_ref")
+_TARGET_COLUMN = CSV_COLUMNS.index("target")
+_STATUS_COLUMN = CSV_COLUMNS.index("status")
 
 
-def _get_git_ref(repo_root: Path) -> str:
-    """Return full 40-char commit SHA from `git rev-parse HEAD`."""
+@dataclass
+class DeployLogSettings:
+    """Mutable deploy-log settings exposed to deployment hooks."""
+    csv_path: Path
+    versioning_enabled: bool = True
+
+
+def _run_git_command(repo_root: Path, args: list[str]) -> str:
+    """Return stripped stdout from a git command, or an empty string."""
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
+            ["git", *args],
             cwd=str(repo_root),
             capture_output=True,
             text=True,
@@ -47,7 +71,23 @@ def _get_git_ref(repo_root: Path) -> str:
         )
         return result.stdout.strip()
     except (subprocess.CalledProcessError, OSError):
-        return "unknown"
+        return ""
+
+
+def _get_git_ref(repo_root: Path) -> str:
+    """Return full 40-char commit SHA from `git rev-parse HEAD`."""
+    return _run_git_command(repo_root, ["rev-parse", "HEAD"]) or "unknown"
+
+
+def _get_local_branch(repo_root: Path) -> str:
+    """Return the checked-out local branch name, or unknown for detached HEAD."""
+    branch = _run_git_command(repo_root, ["branch", "--show-current"])
+    if branch and branch != "HEAD":
+        return branch
+    branch = _run_git_command(repo_root, ["rev-parse", "--abbrev-ref", "HEAD"])
+    if branch and branch != "HEAD":
+        return branch
+    return "unknown"
 
 
 def _read_app_version(repo_root: Path) -> str:
@@ -93,17 +133,38 @@ def get_csv_path(repo_root: Path) -> Path:
     return repo_root / "out" / "deploy" / "deploy_log.csv"
 
 
+def default_deploy_log_settings(repo_root: Path) -> DeployLogSettings:
+    """Return default settings for deploy tracking."""
+    return DeployLogSettings(csv_path=get_csv_path(repo_root))
+
+
+def _resolve_csv_path(*, repo_root: Path, csv_path: Path) -> Path:
+    """Resolve a hook-provided CSV path relative to the repo root."""
+    if csv_path.is_absolute():
+        return csv_path
+    return repo_root / csv_path
+
+
 def _latest_successful_release_git_ref(existing_rows: list[list[str]]) -> str:
     """Return the newest successful production/swap git ref from existing CSV rows."""
     for row in existing_rows:
         if len(row) < len(CSV_COLUMNS):
             continue
-        git_ref = str(row[1] or "").strip()
-        target = str(row[3] or "").strip()
-        status = str(row[7] or "").strip()
+        git_ref = str(row[_GIT_REF_COLUMN] or "").strip()
+        target = str(row[_TARGET_COLUMN] or "").strip()
+        status = str(row[_STATUS_COLUMN] or "").strip()
         if target in {"production", "swap"} and status == "success" and git_ref:
             return git_ref
     return ""
+
+
+def _normalize_existing_row(row: list[str]) -> list[str]:
+    """Return a current-schema deploy log row, backfilling legacy rows."""
+    if len(row) == len(CSV_COLUMNS):
+        return row
+    if len(row) == len(LEGACY_CSV_COLUMNS):
+        return [row[0], row[1], "main", *row[2:]]
+    return row
 
 
 def _should_increment_swap_version(*, target: str, status: str, git_ref: str, existing_rows: list[list[str]]) -> bool:
@@ -123,16 +184,49 @@ def append_deploy_record(
     image: str,
     status: str,
     git_ref: str | None = None,
+    local_branch: str | None = None,
+    version: str | None = None,
+) -> Path:
+    """Write a deploy record to the default CSV log.
+
+    Returns the path to the CSV file.
+    """
+    return append_deploy_record_with_settings(
+        repo_root=repo_root,
+        settings=default_deploy_log_settings(repo_root),
+        target=target,
+        stack_name=stack_name,
+        domain=domain,
+        image=image,
+        status=status,
+        git_ref=git_ref,
+        local_branch=local_branch,
+        version=version,
+    )
+
+
+def append_deploy_record_with_settings(
+    *,
+    repo_root: Path,
+    settings: DeployLogSettings,
+    target: str,
+    stack_name: str,
+    domain: str,
+    image: str,
+    status: str,
+    git_ref: str | None = None,
+    local_branch: str | None = None,
     version: str | None = None,
 ) -> Path:
     """Write a deploy record to the CSV log.
 
     Returns the path to the CSV file.
     """
-    csv_path = get_csv_path(repo_root)
+    csv_path = _resolve_csv_path(repo_root=repo_root, csv_path=settings.csv_path)
     csv_path.parent.mkdir(parents=True, exist_ok=True)
 
     resolved_git_ref = git_ref if git_ref is not None else _get_git_ref(repo_root)
+    resolved_local_branch = local_branch if local_branch is not None else _get_local_branch(repo_root)
     resolved_version = version if version is not None else _read_app_version(repo_root)
     timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -141,11 +235,14 @@ def append_deploy_record(
         with csv_path.open(newline="") as f:
             rows = list(csv.reader(f))
         if rows:
-            existing_rows = rows[1:] if rows[0] == CSV_COLUMNS else rows
+            if rows[0] == CSV_COLUMNS or rows[0] == LEGACY_CSV_COLUMNS:
+                existing_rows = [_normalize_existing_row(row) for row in rows[1:]]
+            else:
+                existing_rows = [_normalize_existing_row(row) for row in rows]
 
     swap_incremented = False
     production_incremented = False
-    if version is None and _should_increment_swap_version(
+    if settings.versioning_enabled and version is None and _should_increment_swap_version(
         target=target,
         status=status,
         git_ref=resolved_git_ref,
@@ -155,7 +252,7 @@ def append_deploy_record(
         if new_version != resolved_version:
             resolved_version = new_version
             swap_incremented = True
-    elif version is None and target == "production" and status == "success":
+    elif settings.versioning_enabled and version is None and target == "production" and status == "success":
         new_version = _increment_patch(resolved_version)
         if new_version != resolved_version:
             resolved_version = new_version
@@ -164,6 +261,7 @@ def append_deploy_record(
     new_row = [
         timestamp,
         resolved_git_ref,
+        resolved_local_branch,
         resolved_version,
         target,
         stack_name,

--- a/scripts/deploy/ubuntu_deploy.py
+++ b/scripts/deploy/ubuntu_deploy.py
@@ -1394,8 +1394,15 @@ def main(argv: list[str] | None = None, repo_root_override: Path | None = None) 
     )
 
     # --- Deploy tracking CSV ------------------------------------------------
-    deploy_log.append_deploy_record(
+    deploy_log_settings = deploy_log.default_deploy_log_settings(repo_root)
+    hooks.call("configure_deploy_log", hook_ctx, hook_plan, deploy_log_settings)
+
+    if not deploy_log_settings.versioning_enabled:
+        log_info("Deploy log versioning disabled by deploy hook.", icon="🪝")
+
+    deploy_log.append_deploy_record_with_settings(
         repo_root=repo_root,
+        settings=deploy_log_settings,
         target="swap" if swap_requested else deploy_target,
         stack_name=resolved_portainer_stack_name,
         domain=resolved_public_domain,

--- a/tests/pytests/test_deploy_log.py
+++ b/tests/pytests/test_deploy_log.py
@@ -9,10 +9,13 @@ import pytest
 
 from scripts.deploy.deploy_log import (
     CSV_COLUMNS,
+    LEGACY_CSV_COLUMNS,
+    DeployLogSettings,
     _increment_patch,
     _read_app_version,
     _write_app_version,
     append_deploy_record,
+    append_deploy_record_with_settings,
     get_csv_path,
 )
 
@@ -89,17 +92,19 @@ class TestAppendDeployRecord:
             image="ghcr.io/user/app:latest",
             status="success",
             git_ref="a" * 40,
+            local_branch="feature/deploy-log-branch",
             version="1.2.3",
         )
         assert csv_path.exists()
         rows = list(csv.reader(csv_path.open()))
         assert rows[0] == CSV_COLUMNS
         assert len(rows) == 2
-        assert rows[1][3] == "staging"
-        assert rows[1][4] == "my-stack"
-        assert rows[1][5] == "staging.example.com"
-        assert rows[1][6] == "ghcr.io/user/app:latest"
-        assert rows[1][7] == "success"
+        assert rows[1][2] == "feature/deploy-log-branch"
+        assert rows[1][4] == "staging"
+        assert rows[1][5] == "my-stack"
+        assert rows[1][6] == "staging.example.com"
+        assert rows[1][7] == "ghcr.io/user/app:latest"
+        assert rows[1][8] == "success"
 
     def test_writes_newest_record_below_header(self, tmp_repo: Path) -> None:
         append_deploy_record(
@@ -110,6 +115,7 @@ class TestAppendDeployRecord:
             image="img1",
             status="success",
             git_ref="b" * 40,
+            local_branch="main",
             version="1.0.0",
         )
         append_deploy_record(
@@ -120,6 +126,7 @@ class TestAppendDeployRecord:
             image="img2",
             status="failed",
             git_ref="c" * 40,
+            local_branch="release/deploy",
             version="1.0.1",
         )
         csv_path = get_csv_path(tmp_repo)
@@ -127,11 +134,41 @@ class TestAppendDeployRecord:
         # Header + 2 data rows
         assert len(rows) == 3
         assert rows[1][1] == "c" * 40
-        assert rows[1][2] == "1.0.1"
-        assert rows[1][3] == "production"
+        assert rows[1][2] == "release/deploy"
+        assert rows[1][3] == "1.0.1"
+        assert rows[1][4] == "production"
         assert rows[2][1] == "b" * 40
-        assert rows[2][2] == "1.0.0"
-        assert rows[2][3] == "staging"
+        assert rows[2][2] == "main"
+        assert rows[2][3] == "1.0.0"
+        assert rows[2][4] == "staging"
+
+    def test_legacy_rows_are_prefilled_with_main(self, tmp_repo: Path) -> None:
+        csv_path = tmp_repo / "out" / "deploy" / "deploy_log.csv"
+        csv_path.parent.mkdir(parents=True)
+        with csv_path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(LEGACY_CSV_COLUMNS)
+            writer.writerow(["2026-05-18T00:00:00Z", "0" * 40, "1.2.3", "swap", "prod-stack", "prod.example.com", "img", "success"])
+
+        csv_path = append_deploy_record(
+            repo_root=tmp_repo,
+            target="staging",
+            stack_name="stg-stack",
+            domain="stg.example.com",
+            image="img",
+            status="success",
+            git_ref="1" * 40,
+            local_branch="feature/deploy-log-branch",
+            version="1.2.4",
+        )
+
+        rows = list(csv.reader(csv_path.open()))
+        assert rows[0] == CSV_COLUMNS
+        assert rows[1][2] == "feature/deploy-log-branch"
+        assert rows[2][1] == "0" * 40
+        assert rows[2][2] == "main"
+        assert rows[2][3] == "1.2.3"
+        assert rows[2][4] == "swap"
 
     def test_production_success_increments_version(self, tmp_repo: Path) -> None:
         csv_path = append_deploy_record(
@@ -142,9 +179,10 @@ class TestAppendDeployRecord:
             image="img",
             status="success",
             git_ref="d" * 40,
+            local_branch="main",
         )
         rows = list(csv.reader(csv_path.open()))
-        assert rows[1][2] == "1.2.4"
+        assert rows[1][3] == "1.2.4"
         # .env should now have APP_VERSION=1.2.4
         content = (tmp_repo / ".env").read_text()
         assert "APP_VERSION=1.2.4" in content
@@ -158,6 +196,7 @@ class TestAppendDeployRecord:
             image="img",
             status="success",
             git_ref="e" * 40,
+            local_branch="main",
         )
         content = (tmp_repo / ".env").read_text()
         assert "APP_VERSION=1.2.3" in content
@@ -168,7 +207,7 @@ class TestAppendDeployRecord:
         with csv_path.open("w", newline="") as f:
             writer = csv.writer(f)
             writer.writerow(CSV_COLUMNS)
-            writer.writerow(["2026-05-18T00:00:00Z", "0" * 40, "1.2.3", "swap", "prod-stack", "prod.example.com", "img", "success"])
+            writer.writerow(["2026-05-18T00:00:00Z", "0" * 40, "main", "1.2.3", "swap", "prod-stack", "prod.example.com", "img", "success"])
 
         csv_path = append_deploy_record(
             repo_root=tmp_repo,
@@ -178,11 +217,12 @@ class TestAppendDeployRecord:
             image="img",
             status="success",
             git_ref="1" * 40,
+            local_branch="release/deploy",
         )
 
         rows = list(csv.reader(csv_path.open()))
-        assert rows[1][2] == "1.2.4"
-        assert rows[1][3] == "swap"
+        assert rows[1][3] == "1.2.4"
+        assert rows[1][4] == "swap"
         content = (tmp_repo / ".env").read_text()
         assert "APP_VERSION=1.2.4" in content
 
@@ -193,7 +233,7 @@ class TestAppendDeployRecord:
         with csv_path.open("w", newline="") as f:
             writer = csv.writer(f)
             writer.writerow(CSV_COLUMNS)
-            writer.writerow(["2026-05-18T00:00:00Z", "1" * 40, "1.2.4", "swap", "prod-stack", "prod.example.com", "img", "success"])
+            writer.writerow(["2026-05-18T00:00:00Z", "1" * 40, "main", "1.2.4", "swap", "prod-stack", "prod.example.com", "img", "success"])
 
         csv_path = append_deploy_record(
             repo_root=tmp_repo,
@@ -203,11 +243,12 @@ class TestAppendDeployRecord:
             image="img",
             status="success",
             git_ref="1" * 40,
+            local_branch="release/deploy",
         )
 
         rows = list(csv.reader(csv_path.open()))
-        assert rows[1][2] == "1.2.4"
-        assert rows[1][3] == "swap"
+        assert rows[1][3] == "1.2.4"
+        assert rows[1][4] == "swap"
         content = (tmp_repo / ".env").read_text()
         assert "APP_VERSION=1.2.4" in content
 
@@ -220,6 +261,7 @@ class TestAppendDeployRecord:
             image="img",
             status="failed",
             git_ref="f" * 40,
+            local_branch="main",
         )
         content = (tmp_repo / ".env").read_text()
         assert "APP_VERSION=1.2.3" in content
@@ -233,13 +275,82 @@ class TestAppendDeployRecord:
             image="",
             status="success",
             git_ref="0" * 40,
+            local_branch="release/deploy",
             version="2.0.0",
         )
         rows = list(csv.reader(csv_path.open()))
         data = rows[1]
-        # timestamp, git_ref, version, target, stack_name, domain, image, status
-        assert len(data) == 8
+        # timestamp, git_ref, local_branch, version, target, stack_name, domain, image, status
+        assert len(data) == 9
         assert data[1] == "0" * 40
-        assert data[2] == "2.0.0"
-        assert data[3] == "swap"
-        assert data[6] == ""
+        assert data[2] == "release/deploy"
+        assert data[3] == "2.0.0"
+        assert data[4] == "swap"
+        assert data[7] == ""
+
+    def test_custom_csv_path_writes_to_requested_path(self, tmp_repo: Path) -> None:
+        settings = DeployLogSettings(csv_path=Path("out/custom/deploy_log.csv"))
+
+        csv_path = append_deploy_record_with_settings(
+            repo_root=tmp_repo,
+            settings=settings,
+            target="staging",
+            stack_name="stg-stack",
+            domain="stg.example.com",
+            image="img",
+            status="success",
+            git_ref="1" * 40,
+            local_branch="feature/deploy-log-hook",
+            version="1.2.3",
+        )
+
+        assert csv_path == tmp_repo / "out" / "custom" / "deploy_log.csv"
+        assert csv_path.exists()
+        assert not get_csv_path(tmp_repo).exists()
+
+    def test_disabled_versioning_keeps_current_production_version(self, tmp_repo: Path) -> None:
+        settings = DeployLogSettings(csv_path=get_csv_path(tmp_repo), versioning_enabled=False)
+
+        csv_path = append_deploy_record_with_settings(
+            repo_root=tmp_repo,
+            settings=settings,
+            target="production",
+            stack_name="prod-stack",
+            domain="prod.example.com",
+            image="img",
+            status="success",
+            git_ref="2" * 40,
+            local_branch="release/deploy",
+        )
+
+        rows = list(csv.reader(csv_path.open()))
+        assert rows[1][3] == "1.2.3"
+        content = (tmp_repo / ".env").read_text()
+        assert "APP_VERSION=1.2.3" in content
+
+    def test_disabled_versioning_keeps_current_swap_version(self, tmp_repo: Path) -> None:
+        csv_path = tmp_repo / "out" / "deploy" / "deploy_log.csv"
+        csv_path.parent.mkdir(parents=True)
+        with csv_path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(CSV_COLUMNS)
+            writer.writerow(["2026-05-18T00:00:00Z", "0" * 40, "main", "1.2.3", "swap", "prod-stack", "prod.example.com", "img", "success"])
+
+        settings = DeployLogSettings(csv_path=get_csv_path(tmp_repo), versioning_enabled=False)
+
+        csv_path = append_deploy_record_with_settings(
+            repo_root=tmp_repo,
+            settings=settings,
+            target="swap",
+            stack_name="prod-stack",
+            domain="prod.example.com",
+            image="img",
+            status="success",
+            git_ref="3" * 40,
+            local_branch="release/deploy",
+        )
+
+        rows = list(csv.reader(csv_path.open()))
+        assert rows[1][3] == "1.2.3"
+        content = (tmp_repo / ".env").read_text()
+        assert "APP_VERSION=1.2.3" in content

--- a/tests/pytests/test_ubuntu_deploy.py
+++ b/tests/pytests/test_ubuntu_deploy.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from scripts.deploy import deploy_log
 from scripts.deploy.ubuntu_deploy import (
     _coerce_label_value,
     _should_fallback_to_remote_compose,
@@ -169,7 +170,11 @@ def test_swap_promotes_to_production_stack_and_stops_only_staging(tmp_path, monk
         monkeypatch.delenv(key, raising=False)
 
     class DummyHooks:
-        def call(self, *args, **kwargs):
+        def call(self, hook_name, *args, **kwargs):
+            if hook_name == "configure_deploy_log":
+                settings = args[2]
+                settings.versioning_enabled = False
+                settings.csv_path = Path("out/custom/deploy_log.csv")
             return None
 
     class DummyResult:
@@ -209,10 +214,26 @@ def test_swap_promotes_to_production_stack_and_stops_only_staging(tmp_path, monk
     monkeypatch.setattr("scripts.deploy.ubuntu_deploy.portainer_helpers.set_portainer_stack_containers_state", fake_set_portainer_stack_containers_state)
     monkeypatch.setattr("scripts.deploy.ubuntu_deploy.caddy_register.ensure_caddy_registration", lambda **kwargs: None)
     monkeypatch.setattr("scripts.deploy.ubuntu_deploy.caddy_register.is_domain_registered", lambda **kwargs: True)
-    deploy_records: list[dict[str, str]] = []
+    deploy_record_targets: list[str] = []
+    deploy_record_settings: list[deploy_log.DeployLogSettings] = []
+
+    def fake_append_deploy_record_with_settings(
+        *,
+        repo_root: Path,
+        settings: deploy_log.DeployLogSettings,
+        target: str,
+        stack_name: str,
+        domain: str,
+        image: str,
+        status: str,
+    ) -> Path:
+        deploy_record_targets.append(target)
+        deploy_record_settings.append(settings)
+        return repo_root / "deploy_log.csv"
+
     monkeypatch.setattr(
-        "scripts.deploy.ubuntu_deploy.deploy_log.append_deploy_record",
-        lambda **kwargs: deploy_records.append(kwargs) or tmp_path / "deploy_log.csv",
+        "scripts.deploy.ubuntu_deploy.deploy_log.append_deploy_record_with_settings",
+        fake_append_deploy_record_with_settings,
     )
     monkeypatch.setattr("scripts.deploy.ubuntu_deploy.deploy_log._read_app_version", lambda repo_root: "1.2.3")
 
@@ -220,7 +241,9 @@ def test_swap_promotes_to_production_stack_and_stops_only_staging(tmp_path, monk
 
     assert deployed_stack_names == ["protected-container"]
     assert state_calls == [("staging-protected-container", "stop")]
-    assert deploy_records[0]["target"] == "swap"
+    assert deploy_record_targets == ["swap"]
+    assert deploy_record_settings[0].versioning_enabled is False
+    assert deploy_record_settings[0].csv_path == Path("out/custom/deploy_log.csv")
 
 
 def test_rewrite_staging_container_names_for_portainer_avoids_production_name_collisions():


### PR DESCRIPTION
# PR Review: Protected-Container Deploy Log Hook

## Problem Statement

Downstream repositories need a supported protected-container hook to control deploy tracking behavior without patching core deploy scripts. Specifically, hooks should be able to disable automatic deploy-log version bumps and redirect where `deploy_log.csv` is written.

## Scope

Repository: `scripts/deploy/_protected-container`

Branch: `improve-versioning`

Base: `main`

## Summary

| Area | Files | Change |
| --- | --- | --- |
| Deploy log model | `scripts/deploy/deploy_log.py` | Adds `DeployLogSettings`, settings-aware append flow, local branch column, legacy CSV row migration, custom CSV path support, and optional version bump disabling. |
| Hook API | `scripts/deploy/deploy_hooks.py` | Adds `configure_deploy_log(ctx, plan, settings)` to the hook protocol. |
| Ubuntu deploy integration | `scripts/deploy/ubuntu_deploy.py` | Creates default deploy-log settings, calls `configure_deploy_log`, logs when versioning is disabled, and writes via the settings-aware deploy-log function. |
| Tests | `tests/pytests/test_deploy_log.py`, `tests/pytests/test_ubuntu_deploy.py` | Covers local branch logging, legacy row migration, custom CSV paths, disabled production/swap versioning, and hook propagation into the Ubuntu deploy flow. |
| Docs/planning | `README.md`, `docs/deploy/HOOKS.md`, `docs/deploy/STAGING.md`, `planning/deploy-tracking-and-staging.md` | Documents the new hook, settings fields, `local_branch` CSV column, and settings-aware writer. |

## Commits

- `b9aa384 feat: Enhance deploy log functionality with customizable settings and local branch tracking`

## Diff Summary

```text
README.md                               |   1 +
docs/deploy/HOOKS.md                    |  18 +++++++++++++++-
docs/deploy/STAGING.md                  |   1 +
planning/deploy-tracking-and-staging.md |   6 ++++--
scripts/deploy/deploy_hooks.py          |   9 +++++++-
scripts/deploy/deploy_log.py            | 122 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-----------
scripts/deploy/ubuntu_deploy.py         |   9 +++++++-
tests/pytests/test_deploy_log.py        | 153 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++------------------
tests/pytests/test_ubuntu_deploy.py     |  33 ++++++++++++++++++++++++-----
9 files changed, 309 insertions(+), 43 deletions(-)
```

## Validation Evidence

```bash
cd /home/ronny/dev/stock-dashboard/scripts/deploy/_protected-container && \
  git --no-pager diff main..HEAD --check && \
  source /home/ronny/dev/stock-dashboard/.venv/bin/activate && \
  python -m py_compile scripts/deploy/deploy_log.py scripts/deploy/deploy_hooks.py scripts/deploy/ubuntu_deploy.py
```

Result: passed.

```bash
cd /home/ronny/dev/stock-dashboard/scripts/deploy/_protected-container && \
  source /home/ronny/dev/stock-dashboard/.venv/bin/activate && \
  python -m pytest \
    tests/pytests/test_deploy_log.py \
    tests/pytests/test_deploy_hooks_unit.py \
    tests/pytests/test_deploy_hooks_integration.py \
    tests/pytests/test_deploy_hooks_compose_integration.py \
    tests/pytests/test_ubuntu_deploy.py \
    -q --tb=short --disable-warnings
```

Result: `79 passed, 2 warnings in 0.35s`.

## API Validation

Not applicable. This change affects local deploy scripts and hook interfaces, not an HTTP or JSON API endpoint.

## Browser Validation

Not applicable. This change has no user-visible browser surface.

## Plan Status

Existing protected-container planning notes were updated in `planning/deploy-tracking-and-staging.md` to reflect:

- `local_branch` in the deploy-log CSV schema.
- legacy row backfill behavior.
- settings-aware deploy-log writes through `append_deploy_record_with_settings(...)`.

The plan was not archived because it is an existing protected-container deploy tracking/staging planning document rather than a newly created one-off plan for this branch.

## Self-Review Checklist

- [x] Scope stays within protected-container deploy-log/hook behavior.
- [x] Hook API is additive and keeps existing hooks optional/no-op compatible.
- [x] Core deploy-log defaults preserve existing behavior when no hook is configured.
- [x] `versioning_enabled=False` suppresses production and swap version bumps while still writing a deploy row.
- [x] Custom CSV paths are resolved relative to `repo_root` unless absolute.
- [x] Legacy 8-column deploy logs are normalized to the 9-column schema with `local_branch=main`.
- [x] Docs explain the new hook and settings fields.
- [x] Focused deploy-log, hook, and Ubuntu deploy tests pass.
- [x] Diff hygiene and Python compile checks pass.

## Residual Risks

- Hook authors must provide `settings.csv_path` as a `Path`, matching the documented interface.
- Existing hook infrastructure still contains pre-existing loose typing (`Any`, mutable env metadata bags). This PR does not broaden that pattern; the new deploy-log settings object is a dataclass.
- Full repository CI has not been run locally; focused protected-container validation for the changed behavior passed.

## Pause Point

Report generated for user review. No PR was created and no merge action was taken.
