### PR TITLE
fix: record merged refs in version log

### DIFF
--- a/.github/skills/changelog/SKILL.md
+++ b/.github/skills/changelog/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: changelog
-description: "Use when: updating CHANGELOG.md, preparing deploy-managed APP_VERSION targets for main-bound merges, turning PR reports into release notes, and documenting new capabilities, fixed bugs, and touched models."
+description: "Use when: updating CHANGELOG.md, incrementing APP_VERSION in .env for main-bound merges, turning PR reports into release notes, and documenting new capabilities, fixed bugs, and touched models."
 ---
 
 # Changelog Workflow
 
 ## Purpose
 
-Use this skill from the merge workflow before a PR is created, updated for final review, or merged into `main`. It turns the PR report into release notes, prepares the next release version entry, and records the models touched by the change.
+Use this skill from the merge workflow before a PR is created, updated for final review, or merged into `main`. It turns the PR report into release notes, bumps the app version, and records the models touched by the change.
 
-In `_protected-container`, `ubuntu_deploy.py` owns the actual `APP_VERSION` write for deploy-managed releases. The changelog step prepares the matching `CHANGELOG.md` entry for the next patch version so the first successful deploy of a new git ref can increment `.env` safely. Do not pre-bump `.env` during normal deploy-managed release preparation.
+In `_protected-container`, `/changelog` owns the `APP_VERSION` bump for main-bound merges. `ubuntu_deploy.py` only verifies that the current `.env` version already has a matching `CHANGELOG.md` entry before it records a new git ref in the deploy log.
 
 `CHANGELOG.md` is the correct conventional filename for release notes in this repo. Use the root `CHANGELOG.md` file. If it is empty, initialize it with:
 
@@ -24,24 +24,23 @@ All notable changes to this project will be documented in this file.
 - A current PR report exists under `out/PR/Review_<branch_slug>.md`.
 - The implementation and validation work is complete enough for merge preparation.
 - Do not read `.env.secrets` or `.env.deploy.secrets`.
-- Use the root `.env` only to read `APP_VERSION` and derive the target deploy version.
-- Remember that `.env*` is ignored by default in this repo. Do not force-add `.env`; for deploy-managed releases, leave the `APP_VERSION` baseline unchanged until `ubuntu_deploy.py` writes the target version after a successful deploy.
+- Use the root `.env` only for `APP_VERSION`.
+- Remember that `.env*` is ignored by default in this repo. Do not force-add `.env`; treat the `APP_VERSION` edit as local runtime configuration unless the repo has intentionally changed that tracking behavior.
 
 If the PR report is stale, regenerate it before writing release notes. If the version class or touched models are unclear, ask the user before editing the changelog.
 
-## Version Target
+## Version Bump
 
-Derive the target release version from root `.env` exactly once per PR that will merge to `main`.
+Increment `APP_VERSION` in the root `.env` exactly once per PR that will merge to `main`.
 
 - Default to a patch bump, for example `0.11.10` -> `0.11.11`.
 - Use a minor bump for a substantial new user-facing capability or API expansion.
 - Use a major bump only for intentional breaking behavior or migration requirements.
 - If `APP_VERSION` is missing, duplicated, or not valid `x.y.z` semver, stop and report the blocker.
-- If the branch already contains a changelog entry for the same PR, update the existing entry instead of choosing another version.
+- If the branch already contains a changelog entry and version bump for the same PR, update the existing entry instead of bumping again.
 - If the branch is rebased or updated from `main` and another merge consumed the target version, bump to the next available version and update the changelog heading.
-- For deploy-managed releases, do not write the target version back to `.env`; `deploy_log.py` persists it after the first successful deploy record for the new git ref.
 
-Verify the local deploy baseline before editing release notes:
+Verify the local version after editing:
 
 ```bash
 grep '^APP_VERSION=' .env
@@ -92,7 +91,7 @@ Use the PR report as the primary source. Use commits and diffs only to verify ac
 2. Identify the version bump class: patch, minor, or major.
 3. Identify touched models from the PR report; if the report does not say, inspect the diff enough to answer accurately without turning the changelog into a file list.
 4. Resolve the PR URL if available, preferring the PR report and then `gh pr view --json number,url` for the current branch. If no PR exists yet, continue without a PR line.
-5. Leave root `.env` unchanged for deploy-managed releases so `ubuntu_deploy.py` can persist the target version after the first successful deploy of the new git ref.
+5. Update root `.env` `APP_VERSION`.
 6. Update root `CHANGELOG.md` with the new version entry.
 7. Review the changelog entry for these gates:
    - It has `New Capabilities`, `Fixed Bugs`, and `Touched Models` sections.
@@ -107,8 +106,8 @@ Use the PR report as the primary source. Use commits and diffs only to verify ac
 
 The changelog step is complete when:
 
-- Root `.env` has a valid current `APP_VERSION` baseline, and the target version has been derived from it.
-- Root `CHANGELOG.md` has the target version entry dated with the merge preparation date.
+- `APP_VERSION` in root `.env` has been bumped once for the main-bound merge, or a clear blocker is reported.
+- Root `CHANGELOG.md` has a versioned entry dated with the merge preparation date.
 - The changelog entry includes a PR link when one is available.
 - The entry summarizes capabilities and fixes, not changed files.
 - Touched models are named, or the entry states `None.`.

--- a/.github/skills/merge/SKILL.md
+++ b/.github/skills/merge/SKILL.md
@@ -95,9 +95,9 @@ git --no-pager log --oneline main..HEAD
 
 **Goal**: prepare the release-note artifacts that accompany a merge to `main`.
 
-1. Load and follow `.github/skills/changelog/SKILL.md` before creating or updating the PR for final review. For `_protected-container`, this step is mandatory for every merge to `main`; do not proceed to PR final review, readiness, or merge until protected `CHANGELOG.md` contains the target version entry required by the deploy version preflight.
+1. Load and follow `.github/skills/changelog/SKILL.md` before creating or updating the PR for final review. For `_protected-container`, this step is mandatory for every merge to `main`; do not proceed to PR final review, readiness, or merge until protected `.env` `APP_VERSION` has been bumped and protected `CHANGELOG.md` contains the matching version entry required by the deploy version preflight.
 2. Use the PR report as the primary source. The changelog entry must summarize new capabilities and fixed bugs, mention touched models, and avoid changed-file details.
-3. Follow the protected changelog skill's version-target rule. For deploy-managed `_protected-container` releases, do not pre-bump root `.env`; `ubuntu_deploy.py` writes the target `APP_VERSION` after the first successful deploy of the new git ref. Because `.env*` is ignored by default in this repo, do not force-add `.env`.
+3. Increment `APP_VERSION` in the root `.env` exactly once for the PR. Because `.env*` is ignored by default in this repo, do not force-add `.env`; treat the bump as local runtime configuration unless the repo has intentionally changed that tracking behavior.
 4. Update root `CHANGELOG.md`; add it to the branch if this is the first tracked changelog entry.
 5. Update or regenerate the PR report if the version, changelog entry, or release-note status changed after the report was generated.
 6. If the version class, release-note summary, or touched models are unclear, pause and ask the user before continuing.
@@ -172,8 +172,11 @@ gh pr merge --squash --delete-branch
 ```bash
 current_branch="$(git branch --show-current)"
 git checkout main && git pull
+source ../../../.venv/bin/activate && python scripts/deploy/deploy_log.py --record-merge
 git branch -D "$current_branch"
 ```
+
+The post-merge version-log command records the merged git ref with the prepared `APP_VERSION` in `out/deploy/version_log.csv`. If the next deploy uses the same git ref, deploy logging reuses that version instead of treating it as a new version event.
 
 16. Remove the local PR report from `out/PR/` after merge unless the repo workflow explicitly keeps PR reports.
 
@@ -197,4 +200,5 @@ Merge completion is done when:
 - Required checks pass.
 - GitHub reports the PR is mergeable with no blocking state.
 - The PR is merged.
+- The merged git ref has been recorded in `out/deploy/version_log.csv` unless version logging was intentionally skipped.
 - Local branch and report cleanup are complete or intentionally deferred with a note.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.4] - 2026-06-09
+
+### New Capabilities
+
+- Clarified the protected merge and changelog workflows so `/changelog` bumps `APP_VERSION` before main-bound merges.
+- Added post-merge version-log recording so the merged git ref is recorded before deploy.
+- Renamed the default deploy tracking CSV from `out/deploy/deploy_log.csv` to `out/deploy/version_log.csv`.
+- Updated deploy documentation to describe deploy logging as a verifier and recorder of prepared release versions.
+
+### Fixed Bugs
+
+- Fixed deploy logging so new git refs record the already-prepared `APP_VERSION` instead of incrementing at deploy time.
+- Fixed repeated deploys of an already logged git ref so they reuse that git ref's recorded version even if local `.env` has advanced for a later release.
+- Fixed direct post-merge deploys so the merge record can seed the version for the same git ref before deployment starts.
+
+### Touched Models
+
+- Version-log CSV versioning contract.
+
 ## [0.2.3] - 2026-06-09
 
 Pull Request: [#33](https://github.com/beejones/protected-container/pull/33)
 
 ### New Capabilities
 
-- Added a protected deploy changelog gate so automatic `APP_VERSION` bumps for new git refs require a matching `CHANGELOG.md` release entry prepared by `/changelog`.
+- Added a protected deploy changelog gate so new git refs require a matching `APP_VERSION` and `CHANGELOG.md` release entry prepared by `/changelog`.
 - Added an Ubuntu deploy preflight that validates the changelog gate before SSH or Portainer deployment work starts.
 
 ### Fixed Bugs
@@ -20,7 +39,7 @@ Pull Request: [#33](https://github.com/beejones/protected-container/pull/33)
 ### Touched Models
 
 - `DeployLogSettings` deploy hook settings dataclass.
-- Deploy tracking CSV versioning contract.
+- Version-log CSV versioning contract.
 
 ## [0.2.2] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.4] - 2026-06-09
 
+Pull Request: [#34](https://github.com/beejones/protected-container/pull/34)
+
 ### New Capabilities
 
 - Clarified the protected merge and changelog workflows so `/changelog` bumps `APP_VERSION` before main-bound merges.

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Common hook uses:
 
 - Allowing additional runtime keys beyond the upstream schema
 - Translating legacy deploy keys (e.g. `GHCR_IMAGE` → `APP_IMAGE`)
-- Customizing deploy log location or disabling deploy-log version bumps
+- Customizing version log location or disabling deploy version preflight checks
 - Post-processing the rendered ACI YAML / Caddyfile (e.g. injecting additional reverse-proxy routes)
 
 #### 4) Ensure CI checks out submodules

--- a/docs/deploy/HOOKS.md
+++ b/docs/deploy/HOOKS.md
@@ -80,9 +80,9 @@ class MyHooks:
         return yaml_text + "\n# Patched by custom hook"
 
     def configure_deploy_log(self, ctx: DeployContext, plan: DeployPlan, settings: DeployLogSettings) -> None:
-        """Called before ubuntu_deploy.py writes the deploy tracking CSV."""
+        """Called before ubuntu_deploy.py writes the version log CSV."""
         settings.versioning_enabled = False
-        settings.csv_path = Path("out/custom/deploy_log.csv")
+        settings.csv_path = Path("out/custom/version_log.csv")
 
 def get_hooks():
     return MyHooks()
@@ -128,13 +128,13 @@ For `ubuntu_deploy.py`, `deploy_result` includes:
 - `default_storage_registration_enabled`
 
 ### `configure_deploy_log(ctx, plan, settings)`
-- **Summary**: Before `ubuntu_deploy.py` writes `deploy_log.csv`.
-- **Use for**: Customizing where deploy tracking is written and whether deploy tracking bumps `APP_VERSION`.
+- **Summary**: Before `ubuntu_deploy.py` writes `version_log.csv`.
+- **Use for**: Customizing where deploy tracking is written and whether deploy tracking enforces prepared `APP_VERSION` release entries.
 
 The `settings` object is mutable:
 
 - `settings.csv_path` (`Path`): CSV path to write. Relative paths are resolved from `ctx.repo_root`.
-- `settings.versioning_enabled` (`bool`, default `True`): when `False`, deploy rows still record the current `APP_VERSION`, but successful deploys do not increment or write `APP_VERSION` back to `.env`. When enabled, the first successful deploy record for a new git ref increments only if `CHANGELOG.md` already has the target version entry from `/changelog`.
+- `settings.versioning_enabled` (`bool`, default `True`): when `False`, deploy rows still record the current `APP_VERSION`, but new git refs do not require a matching `CHANGELOG.md` entry. When enabled, the first successful deploy record for a new git ref records the current `APP_VERSION` only if `CHANGELOG.md` already has the matching version entry from `/changelog`; repeated records for the same git ref reuse the logged version.
 
 ### `on_error(ctx, exc)`
 - **Summary**: If an exception occurs during the deployment lifecycle.

--- a/docs/deploy/STAGING.md
+++ b/docs/deploy/STAGING.md
@@ -58,7 +58,7 @@ Staging is the default target:
 source .venv/bin/activate && python scripts/deploy/ubuntu_deploy.py
 ```
 
-This deploys using `STAGING_*` overrides for domain, remote dir, and stack name. Containers are **created and then stopped via Portainer API**. All other settings (SSH host, compose files, hooks) are shared. If this is the first successful deploy record for the current git ref, the deploy log increments `APP_VERSION` only after `CHANGELOG.md` already contains the target version entry from `/changelog`; later staging, production, or swap deploys for the same git ref reuse that version.
+This deploys using `STAGING_*` overrides for domain, remote dir, and stack name. Containers are **created and then stopped via Portainer API**. All other settings (SSH host, compose files, hooks) are shared. If this is the first successful deploy record for the current git ref, the deploy log records the current `APP_VERSION` only after `CHANGELOG.md` already contains the matching version entry from `/changelog`; later staging, production, or swap deploys for the same git ref reuse that logged version.
 
 ## Deploy to Production
 
@@ -68,7 +68,7 @@ Pass `--prod` to target production:
 source .venv/bin/activate && python scripts/deploy/ubuntu_deploy.py --prod
 ```
 
-This updates and starts production containers, then stops any staging containers. If this is the first successful deploy record for the current git ref, the deploy log increments `APP_VERSION` patch in `.env` only after `/changelog` has prepared the matching `CHANGELOG.md` entry; repeated deploys of the same git ref do not increment it again.
+This updates and starts production containers, then stops any staging containers. If this is the first successful deploy record for the current git ref, the deploy log records the current `APP_VERSION` only after `/changelog` has prepared the matching `CHANGELOG.md` entry; repeated deploys of the same git ref reuse the logged version.
 
 ## Promote Staging to Production
 
@@ -84,13 +84,13 @@ This:
 3. Updates/starts the production Portainer stack
 4. Stops staging containers via Portainer API
 5. Keeps Caddy routing on `PUBLIC_DOMAIN` -> production stack
-6. Logs a `swap` event to the deploy CSV and increments `APP_VERSION` only when the promoted git ref has no earlier successful deploy record and `/changelog` has prepared the target version entry
+6. Logs a `swap` event to the deploy CSV with the current `APP_VERSION`, requiring `/changelog` for new git refs and reusing the logged version for git refs already deployed
 
 Rollback uses a normal production deploy from the desired `git_ref` recorded in the deploy log.
 
-## Deploy Tracking CSV
+## Version Log CSV
 
-Every deploy writes a row to `out/deploy/deploy_log.csv`. The latest record appears directly under the header:
+Every deploy writes a row to `out/deploy/version_log.csv`. The latest record appears directly under the header:
 
 | Column | Example |
 |--------|---------|
@@ -104,7 +104,15 @@ Every deploy writes a row to `out/deploy/deploy_log.csv`. The latest record appe
 | `image` | Container image deployed |
 | `status` | `success` / `failed` |
 
-`APP_VERSION` is recorded in the `version` column for every deploy. The first successful deploy record for a new git ref writes the incremented patch version into the CSV row and persists the same version back to `.env` only when `CHANGELOG.md` already has a `## [x.y.z]` entry for that incremented version. Run `/changelog` before deploying a new git ref. Later staging, production, or swap records for the same git ref reuse that version and do not increment again. Failed deploys never increment `APP_VERSION`.
+`APP_VERSION` is recorded in the `version` column for every deploy. The first successful deploy record for a new git ref records the current `.env` version only when `CHANGELOG.md` already has a matching `## [x.y.z]` entry. Run `/changelog` before deploying a new git ref so `.env` and `CHANGELOG.md` are prepared together. Later staging, production, or swap records for the same git ref reuse the version already recorded for that git ref. Failed deploys never change `APP_VERSION`.
+
+The merge workflow records the merged git ref first:
+
+```bash
+source ../../../.venv/bin/activate && python scripts/deploy/deploy_log.py --record-merge
+```
+
+That writes a `target=merge` row with the prepared `APP_VERSION`. A direct deploy of that same git ref then reuses the merge row's version.
 
 **Rollback from CSV**: Find the latest `production` or `swap` + `success` row, use `git_ref` to checkout that commit, redeploy with `--prod`.
 

--- a/env.example
+++ b/env.example
@@ -1,7 +1,7 @@
 # Runtime environment variables
 # These are uploaded to Azure Key Vault as the 'env' secret
 
-# App version (semver) — auto-incremented once per successfully deployed git ref after /changelog prepares the target entry
+# App version (semver) — bumped by /changelog before main-bound merges, recorded after merge, and verified by deploy logging
 APP_VERSION=0.1.0
 
 # Basic Auth for Caddy (protects code-server access)

--- a/planning/deploy-tracking-and-staging.md
+++ b/planning/deploy-tracking-and-staging.md
@@ -1,10 +1,10 @@
-# Deploy Tracking CSV & Staging Environment
+# Version Log CSV & Staging Environment
 
 ## Principles
 
 - **Deploy history is observable**: Every successful deploy writes a row to a CSV log so operators can trace exactly what was deployed and when. The newest row appears directly below the header.
 - **Git commit is the rollback anchor**: The CSV records the **full 40-char commit SHA** (`git rev-parse HEAD`) so you can always `git checkout <sha>` to reproduce exactly what was deployed.
-- **Version lives in `.env` as `APP_VERSION`**: Format `x.y.z` (semver). The deploy script reads it, logs it to the CSV, and optionally auto-increments the patch (`z`) for the first successful deploy record of a new git ref only after `/changelog` has prepared the matching `CHANGELOG.md` entry. Later staging, production, or swap records for the same git ref reuse that version.
+- **Version lives in `.env` as `APP_VERSION`**: Format `x.y.z` (semver). `/changelog` bumps it for main-bound merges and writes the matching `CHANGELOG.md` entry. The deploy script reads that prepared version, logs it to the CSV for the first successful deploy record of a new git ref, and requires the matching changelog entry. Later staging, production, or swap records for the same git ref reuse the logged version.
 - **CSV columns and their purpose**:
   | Column | Value | Why |
   |--------|-------|-----|
@@ -27,7 +27,7 @@
   3. Updates/starts the production Portainer stack from the Compose/image contract
   4. Stops staging containers via Portainer API
   5. Keeps Caddy routing on `PUBLIC_DOMAIN` → production stack
-  6. Logs a `swap` event to the deploy CSV without incrementing `APP_VERSION` again when staging already recorded the same git ref
+  6. Logs a `swap` event to the version CSV, reusing the staged version when staging already recorded the same git ref
 
   **Why not route production to staging?** Staging must remain stopped after deploy and after swap. Promoting into production preserves the stable public route while keeping staging as a stopped predeploy candidate.
 
@@ -57,7 +57,7 @@
 - [x] Remove any dead code found
 - [x] Verify existing tests pass after cleanup (`pytest -q`)
 
-### Phase 1 — Deploy Tracking CSV (`out/deploy/deploy_log.csv`)
+### Phase 1 — Version Log CSV (`out/deploy/version_log.csv`)
 - [x] Add `APP_VERSION=0.1.0` to `.env` (runtime config, read at deploy time)
 - [x] Add `APP_VERSION` to `env_schema.py` RUNTIME_SCHEMA (optional, default `0.0.0`)
 - [x] Create `scripts/deploy/deploy_log.py` with:
@@ -67,7 +67,7 @@
   - `git_ref` = full 40-char SHA from `git rev-parse HEAD`
   - `local_branch` = checked-out deploy branch, with legacy rows backfilled as `main`
   - `version` = read from `.env` key `APP_VERSION`
-  - After the first successful deploy record for a new git ref: auto-increment patch in `.env` (`1.2.3` -> `1.2.4`) so each git ref gets one release version, but only if `CHANGELOG.md` already has the target `## [1.2.4]` entry from `/changelog`
+  - After the first successful deploy record for a new git ref: record the current `.env` `APP_VERSION` so each git ref gets one release version, but only if `CHANGELOG.md` already has the matching version entry from `/changelog`
   - Repeated staging, production, and swap deploys for the same git ref: log current version but do NOT increment
 - [x] Integrate `append_deploy_record` call at end of `ubuntu_deploy.py` main()
 - [x] Add `out/deploy/` to `.gitignore` (tracking CSV is local state, not committed)
@@ -92,7 +92,7 @@
   - Updates/starts the production Portainer stack from the Compose/image contract
   - Keeps Caddy routing on `PUBLIC_DOMAIN` → production stack
   - Stops staging containers via Portainer API
-  - Writes a `swap` event to the deploy CSV without incrementing `APP_VERSION` again when staging already recorded the same git ref
+  - Writes a `swap` event to the version CSV, reusing the staged version when staging already recorded the same git ref
   - Fails clearly if staging has not been deployed yet
 - [x] Write integration tests for swap promotion logic (mock SSH + Portainer calls)
 
@@ -170,7 +170,7 @@ timestamp,git_ref,version,target,stack_name,domain,image,status
 3. Update/start the production Portainer stack
 4. Stop staging containers through the Portainer API
 5. Keep Caddy routing on `PUBLIC_DOMAIN` → production stack
-6. Log a `swap` event to CSV without incrementing `APP_VERSION` again when staging already recorded the same git ref
+6. Log a `swap` event to CSV, reusing the staged version when staging already recorded the same git ref
 
 This is a **promotion swap**: public traffic always routes to production, and staging is stopped after staging deploys and after swaps.
 
@@ -223,12 +223,12 @@ After swap:
   2. Promote the staged configuration to the production stack
   3. Keep Caddy routing on `PUBLIC_DOMAIN` → production stack
   4. Stop staging containers
-  5. Log swap event to CSV without incrementing `APP_VERSION` again when staging already recorded the same git ref
+  5. Log swap event to CSV, reusing the staged version when staging already recorded the same git ref
 - [x] Rollback uses the deploy-log `git_ref` and a production deploy
 - [x] Storage-manager only runs on the active stack — no cleanup conflict
 - [x] Update `docs/deploy/STAGING.md` with the shared-volume model
 - [x] Add deploy message: show which containers are being stopped/started
 - [x] Tests for stop/start lifecycle logic
-- [x] Latest `out/deploy/deploy_log.csv` record is written directly below the header
-- [x] Deploy log includes APP_VERSION in the `version` column for staging, production, and swap records
-- [x] Deploy log includes the checked-out branch in the `local_branch` column
+- [x] Latest `out/deploy/version_log.csv` record is written directly below the header
+- [x] Version log includes APP_VERSION in the `version` column for staging, production, and swap records
+- [x] Version log includes the checked-out branch in the `local_branch` column

--- a/scripts/deploy/deploy_log.py
+++ b/scripts/deploy/deploy_log.py
@@ -1,17 +1,18 @@
-"""Deploy tracking CSV logger.
+"""Version log CSV logger.
 
-Writes a row to `out/deploy/deploy_log.csv` after each deploy, recording
+Writes a row to `out/deploy/version_log.csv` after each deploy, recording
 the git ref, local branch, version, target environment, stack name, domain,
 image, and status.
 Newest records are stored directly under the CSV header.
 
-After the first successful deploy of a new git ref, auto-increments the patch
-component of APP_VERSION in `.env`. Later deploy records for that same git ref
-reuse the existing version.
+For a new git ref, the current APP_VERSION must already have a matching
+CHANGELOG.md entry from /changelog. Later deploy records for that same git ref
+reuse the version already recorded in the deploy log.
 """
 
 from __future__ import annotations
 
+import argparse
 import csv
 import re
 import subprocess
@@ -45,10 +46,10 @@ LEGACY_CSV_COLUMNS = [
     "status",
 ]
 
-_SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 _CHANGELOG_VERSION_HEADING_RE = re.compile(r"^## \[(?P<version>\d+\.\d+\.\d+)\]")
 _GIT_REF_COLUMN = CSV_COLUMNS.index("git_ref")
 _STATUS_COLUMN = CSV_COLUMNS.index("status")
+_MERGE_TARGET = "merge"
 
 
 @dataclass
@@ -98,15 +99,6 @@ def _read_app_version(repo_root: Path) -> str:
     return str(values.get("APP_VERSION") or "0.0.0").strip() or "0.0.0"
 
 
-def _increment_patch(version: str) -> str:
-    """Increment the patch component of a semver string."""
-    match = _SEMVER_RE.match(version.strip())
-    if not match:
-        return version
-    major, minor, patch = int(match.group(1)), int(match.group(2)), int(match.group(3))
-    return f"{major}.{minor}.{patch + 1}"
-
-
 def _write_app_version(repo_root: Path, new_version: str) -> None:
     """Update APP_VERSION in .env in-place."""
     env_path = repo_root / ".env"
@@ -140,7 +132,7 @@ def _changelog_has_version_entry(repo_root: Path, version: str) -> bool:
 
 
 def _require_changelog_entry_for_version(repo_root: Path, version: str) -> None:
-    """Fail before a deploy version bump if /changelog has not prepared it."""
+    """Fail before deploying a version that /changelog has not prepared."""
     if _changelog_has_version_entry(repo_root, version):
         return
     raise RuntimeError(
@@ -149,8 +141,8 @@ def _require_changelog_entry_for_version(repo_root: Path, version: str) -> None:
 
 
 def get_csv_path(repo_root: Path) -> Path:
-    """Return the path to the deploy log CSV."""
-    return repo_root / "out" / "deploy" / "deploy_log.csv"
+    """Return the path to the version log CSV."""
+    return repo_root / "out" / "deploy" / "version_log.csv"
 
 
 def default_deploy_log_settings(repo_root: Path) -> DeployLogSettings:
@@ -177,6 +169,18 @@ def _latest_successful_deploy_git_ref(existing_rows: list[list[str]]) -> str:
     return ""
 
 
+def _successful_deploy_version_for_git_ref(*, git_ref: str, existing_rows: list[list[str]]) -> str:
+    """Return the newest successful deploy version for a git ref."""
+    for row in existing_rows:
+        if len(row) < len(CSV_COLUMNS):
+            continue
+        row_git_ref = str(row[_GIT_REF_COLUMN] or "").strip()
+        status = str(row[_STATUS_COLUMN] or "").strip()
+        if status == "success" and row_git_ref == git_ref:
+            return str(row[CSV_COLUMNS.index("version")] or "").strip()
+    return ""
+
+
 def _normalize_existing_row(row: list[str]) -> list[str]:
     """Return a current-schema deploy log row, backfilling legacy rows."""
     if len(row) == len(CSV_COLUMNS):
@@ -199,15 +203,15 @@ def _read_existing_deploy_rows(csv_path: Path) -> list[list[str]]:
     return [_normalize_existing_row(row) for row in rows]
 
 
-def _should_increment_deploy_version(*, status: str, git_ref: str, existing_rows: list[list[str]]) -> bool:
-    """True when a successful deploy records a new git ref."""
+def _requires_new_version_record(*, status: str, git_ref: str, existing_rows: list[list[str]]) -> bool:
+    """True when a successful event records a new git ref."""
     if status != "success":
         return False
     latest_deploy_git_ref = _latest_successful_deploy_git_ref(existing_rows)
     return not latest_deploy_git_ref or latest_deploy_git_ref != git_ref
 
 
-def require_changelog_for_pending_version_increment(
+def require_changelog_for_pending_version_record(
     *,
     repo_root: Path,
     settings: DeployLogSettings,
@@ -215,22 +219,20 @@ def require_changelog_for_pending_version_increment(
     git_ref: str | None = None,
     version: str | None = None,
 ) -> None:
-    """Validate a pending automatic version bump without writing deploy state."""
+    """Validate the merge-prepared version before writing deploy state."""
     if not settings.versioning_enabled or version is not None:
         return
     csv_path = _resolve_csv_path(repo_root=repo_root, csv_path=settings.csv_path)
     existing_rows = _read_existing_deploy_rows(csv_path)
     resolved_git_ref = git_ref if git_ref is not None else _get_git_ref(repo_root)
-    if not _should_increment_deploy_version(
+    if not _requires_new_version_record(
         status=status,
         git_ref=resolved_git_ref,
         existing_rows=existing_rows,
     ):
         return
     resolved_version = _read_app_version(repo_root)
-    new_version = _increment_patch(resolved_version)
-    if new_version != resolved_version:
-        _require_changelog_entry_for_version(repo_root, new_version)
+    _require_changelog_entry_for_version(repo_root, resolved_version)
 
 
 def append_deploy_record(
@@ -290,17 +292,19 @@ def append_deploy_record_with_settings(
 
     existing_rows = _read_existing_deploy_rows(csv_path)
 
-    version_incremented = False
-    if settings.versioning_enabled and version is None and _should_increment_deploy_version(
-        status=status,
-        git_ref=resolved_git_ref,
-        existing_rows=existing_rows,
-    ):
-        new_version = _increment_patch(resolved_version)
-        if new_version != resolved_version:
-            _require_changelog_entry_for_version(repo_root, new_version)
-            resolved_version = new_version
-            version_incremented = True
+    if settings.versioning_enabled and version is None:
+        existing_version = _successful_deploy_version_for_git_ref(
+            git_ref=resolved_git_ref,
+            existing_rows=existing_rows,
+        )
+        if existing_version:
+            resolved_version = existing_version
+        elif _requires_new_version_record(
+            status=status,
+            git_ref=resolved_git_ref,
+            existing_rows=existing_rows,
+        ):
+            _require_changelog_entry_for_version(repo_root, resolved_version)
 
     new_row = [
         timestamp,
@@ -320,8 +324,68 @@ def append_deploy_record_with_settings(
         writer.writerow(new_row)
         writer.writerows(existing_rows)
 
-    # Persist any automatic release-version bump after the row is written.
-    if version_incremented:
-        _write_app_version(repo_root, resolved_version)
-
     return csv_path
+
+
+def append_merge_record(
+    *,
+    repo_root: Path,
+    settings: DeployLogSettings | None = None,
+    git_ref: str | None = None,
+    local_branch: str | None = None,
+    version: str | None = None,
+) -> Path:
+    """Record a post-merge version row unless the git ref is already logged."""
+    resolved_settings = settings if settings is not None else default_deploy_log_settings(repo_root)
+    csv_path = _resolve_csv_path(repo_root=repo_root, csv_path=resolved_settings.csv_path)
+    existing_rows = _read_existing_deploy_rows(csv_path)
+    resolved_git_ref = git_ref if git_ref is not None else _get_git_ref(repo_root)
+    if _successful_deploy_version_for_git_ref(git_ref=resolved_git_ref, existing_rows=existing_rows):
+        return csv_path
+
+    resolved_version = version if version is not None else _read_app_version(repo_root)
+    if resolved_settings.versioning_enabled and version is None:
+        _require_changelog_entry_for_version(repo_root, resolved_version)
+
+    return append_deploy_record_with_settings(
+        repo_root=repo_root,
+        settings=resolved_settings,
+        target=_MERGE_TARGET,
+        stack_name="",
+        domain="",
+        image="",
+        status="success",
+        git_ref=resolved_git_ref,
+        local_branch=local_branch,
+        version=resolved_version,
+    )
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """Build the version-log CLI parser."""
+    parser = argparse.ArgumentParser(description="Update the protected version log.")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--csv-path", type=Path, default=None)
+    parser.add_argument("--record-merge", action="store_true")
+    parser.add_argument("--disable-versioning", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint for version-log maintenance."""
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    if not args.record_merge:
+        parser.error("choose an action, for example --record-merge")
+    settings = DeployLogSettings(
+        csv_path=args.csv_path if args.csv_path is not None else get_csv_path(repo_root),
+        versioning_enabled=not args.disable_versioning,
+    )
+    csv_path = append_merge_record(repo_root=repo_root, settings=settings)
+    print(f"Version log ready: {csv_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy/ubuntu_deploy.py
+++ b/scripts/deploy/ubuntu_deploy.py
@@ -1019,7 +1019,7 @@ def main(argv: list[str] | None = None, repo_root_override: Path | None = None) 
     hooks.call("configure_deploy_log", hook_ctx, hook_plan, deploy_log_settings)
     if not deploy_log_settings.versioning_enabled:
         log_info("Deploy log versioning disabled by deploy hook.", icon="🪝")
-    deploy_log.require_changelog_for_pending_version_increment(
+    deploy_log.require_changelog_for_pending_version_record(
         repo_root=repo_root,
         settings=deploy_log_settings,
         status="success",
@@ -1403,7 +1403,7 @@ def main(argv: list[str] | None = None, repo_root_override: Path | None = None) 
         },
     )
 
-    # --- Deploy tracking CSV ------------------------------------------------
+    # --- Version log CSV ----------------------------------------------------
     deploy_log.append_deploy_record_with_settings(
         repo_root=repo_root,
         settings=deploy_log_settings,

--- a/tests/pytests/test_deploy_log.py
+++ b/tests/pytests/test_deploy_log.py
@@ -11,11 +11,11 @@ from scripts.deploy.deploy_log import (
     CSV_COLUMNS,
     LEGACY_CSV_COLUMNS,
     DeployLogSettings,
-    _increment_patch,
     _read_app_version,
     _write_app_version,
     append_deploy_record,
     append_deploy_record_with_settings,
+    append_merge_record,
     get_csv_path,
 )
 
@@ -26,25 +26,8 @@ def tmp_repo(tmp_path: Path) -> Path:
     env_file = tmp_path / ".env"
     env_file.write_text("APP_VERSION=1.2.3\nBASIC_AUTH_USER=admin\n")
     changelog_file = tmp_path / "CHANGELOG.md"
-    changelog_file.write_text("# Changelog\n\n## [1.2.4] - 2026-06-09\n")
+    changelog_file.write_text("# Changelog\n\n## [1.2.3] - 2026-06-09\n")
     return tmp_path
-
-
-class TestIncrementPatch:
-    def test_normal(self) -> None:
-        assert _increment_patch("1.2.3") == "1.2.4"
-
-    def test_zero(self) -> None:
-        assert _increment_patch("0.0.0") == "0.0.1"
-
-    def test_large_patch(self) -> None:
-        assert _increment_patch("1.0.99") == "1.0.100"
-
-    def test_invalid_returns_unchanged(self) -> None:
-        assert _increment_patch("not-semver") == "not-semver"
-
-    def test_partial_returns_unchanged(self) -> None:
-        assert _increment_patch("1.2") == "1.2"
 
 
 class TestReadAppVersion:
@@ -81,7 +64,7 @@ class TestWriteAppVersion:
 class TestGetCsvPath:
     def test_returns_expected_path(self, tmp_path: Path) -> None:
         result = get_csv_path(tmp_path)
-        assert result == tmp_path / "out" / "deploy" / "deploy_log.csv"
+        assert result == tmp_path / "out" / "deploy" / "version_log.csv"
 
 
 class TestAppendDeployRecord:
@@ -145,7 +128,7 @@ class TestAppendDeployRecord:
         assert rows[2][4] == "staging"
 
     def test_legacy_rows_are_prefilled_with_main(self, tmp_repo: Path) -> None:
-        csv_path = tmp_repo / "out" / "deploy" / "deploy_log.csv"
+        csv_path = tmp_repo / "out" / "deploy" / "version_log.csv"
         csv_path.parent.mkdir(parents=True)
         with csv_path.open("w", newline="") as f:
             writer = csv.writer(f)
@@ -172,7 +155,7 @@ class TestAppendDeployRecord:
         assert rows[2][3] == "1.2.3"
         assert rows[2][4] == "swap"
 
-    def test_production_success_increments_version(self, tmp_repo: Path) -> None:
+    def test_production_success_records_prepared_version(self, tmp_repo: Path) -> None:
         csv_path = append_deploy_record(
             repo_root=tmp_repo,
             target="production",
@@ -184,13 +167,83 @@ class TestAppendDeployRecord:
             local_branch="main",
         )
         rows = list(csv.reader(csv_path.open()))
-        assert rows[1][3] == "1.2.4"
-        # .env should now have APP_VERSION=1.2.4
+        assert rows[1][3] == "1.2.3"
         content = (tmp_repo / ".env").read_text()
-        assert "APP_VERSION=1.2.4" in content
+        assert "APP_VERSION=1.2.3" in content
+
+    def test_merge_record_records_prepared_version(self, tmp_repo: Path) -> None:
+        csv_path = append_merge_record(
+            repo_root=tmp_repo,
+            git_ref="d" * 40,
+            local_branch="main",
+        )
+
+        rows = list(csv.reader(csv_path.open()))
+        assert rows[0] == CSV_COLUMNS
+        assert rows[1][1] == "d" * 40
+        assert rows[1][2] == "main"
+        assert rows[1][3] == "1.2.3"
+        assert rows[1][4] == "merge"
+        assert rows[1][5] == ""
+        assert rows[1][6] == ""
+        assert rows[1][7] == ""
+        assert rows[1][8] == "success"
+
+    def test_merge_record_requires_changelog_entry(self, tmp_repo: Path) -> None:
+        _write_app_version(tmp_repo, "1.2.4")
+        (tmp_repo / "CHANGELOG.md").write_text("# Changelog\n\n## [1.2.3] - 2026-06-08\n")
+
+        with pytest.raises(RuntimeError, match="Run /changelog"):
+            append_merge_record(
+                repo_root=tmp_repo,
+                git_ref="d" * 40,
+                local_branch="main",
+            )
+
+        assert not get_csv_path(tmp_repo).exists()
+
+    def test_merge_record_is_idempotent_for_existing_git_ref(self, tmp_repo: Path) -> None:
+        csv_path = append_merge_record(
+            repo_root=tmp_repo,
+            git_ref="d" * 40,
+            local_branch="main",
+        )
+        csv_path = append_merge_record(
+            repo_root=tmp_repo,
+            git_ref="d" * 40,
+            local_branch="main",
+        )
+
+        rows = list(csv.reader(csv_path.open()))
+        assert len(rows) == 2
+
+    def test_deploy_reuses_post_merge_version_for_same_git_ref(self, tmp_repo: Path) -> None:
+        append_merge_record(
+            repo_root=tmp_repo,
+            git_ref="d" * 40,
+            local_branch="main",
+        )
+        _write_app_version(tmp_repo, "1.2.4")
+
+        csv_path = append_deploy_record(
+            repo_root=tmp_repo,
+            target="production",
+            stack_name="prod-stack",
+            domain="prod.example.com",
+            image="img",
+            status="success",
+            git_ref="d" * 40,
+            local_branch="main",
+        )
+
+        rows = list(csv.reader(csv_path.open()))
+        assert rows[1][3] == "1.2.3"
+        assert rows[1][4] == "production"
+        assert rows[2][3] == "1.2.3"
+        assert rows[2][4] == "merge"
 
     def test_staging_success_for_same_git_ref_does_not_increment_again(self, tmp_repo: Path) -> None:
-        csv_path = tmp_repo / "out" / "deploy" / "deploy_log.csv"
+        csv_path = tmp_repo / "out" / "deploy" / "version_log.csv"
         csv_path.parent.mkdir(parents=True)
         with csv_path.open("w", newline="") as f:
             writer = csv.writer(f)
@@ -210,8 +263,10 @@ class TestAppendDeployRecord:
         content = (tmp_repo / ".env").read_text()
         assert "APP_VERSION=1.2.3" in content
 
-    def test_staging_success_for_new_git_ref_increments_version(self, tmp_repo: Path) -> None:
-        csv_path = tmp_repo / "out" / "deploy" / "deploy_log.csv"
+    def test_staging_success_for_new_git_ref_records_prepared_version(self, tmp_repo: Path) -> None:
+        _write_app_version(tmp_repo, "1.2.4")
+        (tmp_repo / "CHANGELOG.md").write_text("# Changelog\n\n## [1.2.4] - 2026-06-09\n")
+        csv_path = tmp_repo / "out" / "deploy" / "version_log.csv"
         csv_path.parent.mkdir(parents=True)
         with csv_path.open("w", newline="") as f:
             writer = csv.writer(f)
@@ -235,7 +290,8 @@ class TestAppendDeployRecord:
         content = (tmp_repo / ".env").read_text()
         assert "APP_VERSION=1.2.4" in content
 
-    def test_new_git_ref_increment_requires_changelog_entry(self, tmp_repo: Path) -> None:
+    def test_new_git_ref_prepared_version_requires_changelog_entry(self, tmp_repo: Path) -> None:
+        _write_app_version(tmp_repo, "1.2.4")
         (tmp_repo / "CHANGELOG.md").write_text("# Changelog\n\n## [1.2.3] - 2026-06-08\n")
 
         with pytest.raises(RuntimeError, match="Run /changelog"):
@@ -251,11 +307,13 @@ class TestAppendDeployRecord:
             )
 
         content = (tmp_repo / ".env").read_text()
-        assert "APP_VERSION=1.2.3" in content
+        assert "APP_VERSION=1.2.4" in content
         assert not get_csv_path(tmp_repo).exists()
 
-    def test_swap_success_for_new_git_ref_increments_version(self, tmp_repo: Path) -> None:
-        csv_path = tmp_repo / "out" / "deploy" / "deploy_log.csv"
+    def test_swap_success_for_new_git_ref_records_prepared_version(self, tmp_repo: Path) -> None:
+        _write_app_version(tmp_repo, "1.2.4")
+        (tmp_repo / "CHANGELOG.md").write_text("# Changelog\n\n## [1.2.4] - 2026-06-09\n")
+        csv_path = tmp_repo / "out" / "deploy" / "version_log.csv"
         csv_path.parent.mkdir(parents=True)
         with csv_path.open("w", newline="") as f:
             writer = csv.writer(f)
@@ -279,9 +337,34 @@ class TestAppendDeployRecord:
         content = (tmp_repo / ".env").read_text()
         assert "APP_VERSION=1.2.4" in content
 
+    def test_same_git_ref_reuses_existing_deploy_version_even_if_env_changed(self, tmp_repo: Path) -> None:
+        _write_app_version(tmp_repo, "1.2.4")
+        csv_path = tmp_repo / "out" / "deploy" / "version_log.csv"
+        csv_path.parent.mkdir(parents=True)
+        with csv_path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(CSV_COLUMNS)
+            writer.writerow(["2026-05-18T00:00:00Z", "1" * 40, "main", "1.2.3", "staging", "stg-stack", "stg.example.com", "img", "success"])
+
+        csv_path = append_deploy_record(
+            repo_root=tmp_repo,
+            target="swap",
+            stack_name="prod-stack",
+            domain="prod.example.com",
+            image="img",
+            status="success",
+            git_ref="1" * 40,
+            local_branch="release/deploy",
+        )
+
+        rows = list(csv.reader(csv_path.open()))
+        assert rows[1][3] == "1.2.3"
+        content = (tmp_repo / ".env").read_text()
+        assert "APP_VERSION=1.2.4" in content
+
     def test_swap_success_for_same_git_ref_does_not_increment_again(self, tmp_repo: Path) -> None:
         _write_app_version(tmp_repo, "1.2.4")
-        csv_path = tmp_repo / "out" / "deploy" / "deploy_log.csv"
+        csv_path = tmp_repo / "out" / "deploy" / "version_log.csv"
         csv_path.parent.mkdir(parents=True)
         with csv_path.open("w", newline="") as f:
             writer = csv.writer(f)
@@ -307,7 +390,7 @@ class TestAppendDeployRecord:
 
     def test_swap_success_after_staging_same_git_ref_does_not_increment_again(self, tmp_repo: Path) -> None:
         _write_app_version(tmp_repo, "1.2.4")
-        csv_path = tmp_repo / "out" / "deploy" / "deploy_log.csv"
+        csv_path = tmp_repo / "out" / "deploy" / "version_log.csv"
         csv_path.parent.mkdir(parents=True)
         with csv_path.open("w", newline="") as f:
             writer = csv.writer(f)
@@ -369,7 +452,7 @@ class TestAppendDeployRecord:
         assert data[7] == ""
 
     def test_custom_csv_path_writes_to_requested_path(self, tmp_repo: Path) -> None:
-        settings = DeployLogSettings(csv_path=Path("out/custom/deploy_log.csv"))
+        settings = DeployLogSettings(csv_path=Path("out/custom/version_log.csv"))
 
         csv_path = append_deploy_record_with_settings(
             repo_root=tmp_repo,
@@ -384,7 +467,7 @@ class TestAppendDeployRecord:
             version="1.2.3",
         )
 
-        assert csv_path == tmp_repo / "out" / "custom" / "deploy_log.csv"
+        assert csv_path == tmp_repo / "out" / "custom" / "version_log.csv"
         assert csv_path.exists()
         assert not get_csv_path(tmp_repo).exists()
 
@@ -409,7 +492,7 @@ class TestAppendDeployRecord:
         assert "APP_VERSION=1.2.3" in content
 
     def test_disabled_versioning_keeps_current_swap_version(self, tmp_repo: Path) -> None:
-        csv_path = tmp_repo / "out" / "deploy" / "deploy_log.csv"
+        csv_path = tmp_repo / "out" / "deploy" / "version_log.csv"
         csv_path.parent.mkdir(parents=True)
         with csv_path.open("w", newline="") as f:
             writer = csv.writer(f)

--- a/tests/pytests/test_ubuntu_deploy.py
+++ b/tests/pytests/test_ubuntu_deploy.py
@@ -174,7 +174,7 @@ def test_swap_promotes_to_production_stack_and_stops_only_staging(tmp_path, monk
             if hook_name == "configure_deploy_log":
                 settings = args[2]
                 settings.versioning_enabled = False
-                settings.csv_path = Path("out/custom/deploy_log.csv")
+                settings.csv_path = Path("out/custom/version_log.csv")
             return None
 
     class DummyResult:
@@ -229,7 +229,7 @@ def test_swap_promotes_to_production_stack_and_stops_only_staging(tmp_path, monk
     ) -> Path:
         deploy_record_targets.append(target)
         deploy_record_settings.append(settings)
-        return repo_root / "deploy_log.csv"
+        return repo_root / "version_log.csv"
 
     monkeypatch.setattr(
         "scripts.deploy.ubuntu_deploy.deploy_log.append_deploy_record_with_settings",
@@ -243,14 +243,14 @@ def test_swap_promotes_to_production_stack_and_stops_only_staging(tmp_path, monk
     assert state_calls == [("staging-protected-container", "stop")]
     assert deploy_record_targets == ["swap"]
     assert deploy_record_settings[0].versioning_enabled is False
-    assert deploy_record_settings[0].csv_path == Path("out/custom/deploy_log.csv")
+    assert deploy_record_settings[0].csv_path == Path("out/custom/version_log.csv")
 
 
 def test_main_requires_changelog_entry_before_remote_work(tmp_path, monkeypatch):
     (tmp_path / "docker").mkdir()
     (tmp_path / "docker" / "docker-compose.yml").write_text("services: {}\n")
     (tmp_path / "docker" / "docker-compose.ubuntu.yml").write_text("services: {}\n")
-    (tmp_path / ".env").write_text("APP_VERSION=1.2.3\n")
+    (tmp_path / ".env").write_text("APP_VERSION=1.2.4\n")
     (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\n## [1.2.3] - 2026-06-09\n")
     (tmp_path / ".env.deploy").write_text(
         "\n".join(


### PR DESCRIPTION
# PR Review: Merge-Owned Version Logging

Pull Request: [#34](https://github.com/beejones/protected-container/pull/34)

## Problem Statement

Protected-container version ownership was ambiguous. The merge and changelog workflows said main-bound changes should prepare `APP_VERSION`, while deploy logging still behaved like deploy owned version events. That created two problems: a merge did not reliably seed the version log, and a direct deploy of the same merged git ref could be treated like the first version event.

## Root Cause

Version logging only happened during deploy. There was no post-merge version-log record for the merged git ref, and parts of the protected workflow/docs still described deploy-time version ownership or the old `deploy_log.csv` filename.

## Change Summary

| Area | Summary |
| --- | --- |
| Version logging | Changed the default CSV path to `out/deploy/version_log.csv`, added merge-row recording, and made repeated git refs reuse existing logged versions. |
| Deploy preflight | Renamed internal version-record helpers away from obsolete increment semantics and kept changelog validation on prepared versions. |
| Merge workflow | Added a post-merge command that records the merged git ref before branch cleanup. |
| Root wrapper | Added `scripts/deploy/version_log.py` in stock-dashboard so downstream repos can record merge rows through the protected implementation. |
| Docs/examples | Updated staging, hooks, README, env examples, planning notes, and changelog entries to describe the new contract. |
| Tests | Added regression coverage for merge rows, idempotency, changelog enforcement, deploy reuse, and the root wrapper argument behavior. |

## Commit List

- `6d28c1b` fix: record merged refs in version log

## Validation Evidence

- `source ../../../.venv/bin/activate && python -m pytest tests/pytests/test_deploy_log.py -q` from `_protected-container`: `32 passed`.
- `source .venv/bin/activate && python -m pytest tests/pytests/test_deploy_staging_support.py scripts/deploy/_protected-container/tests/pytests/test_deploy_log.py scripts/deploy/_protected-container/tests/pytests/test_ubuntu_deploy.py -q` from stock-dashboard root: `77 passed`.
- CLI smoke check created `target=merge` rows for temporary root and protected repos with `python scripts/deploy/version_log.py --record-merge` and `python scripts/deploy/deploy_log.py --record-merge`.
- `git diff --check` passed in stock-dashboard root and `_protected-container`.
- Editor diagnostics reported no errors for changed Python, test, docs, and skill files.
- Stale-reference checks found no remaining `deploy_log.csv`, `pending_version_increment`, `should_increment_deploy_version`, or `_increment_patch` references in tracked touched surfaces.

## API Validation

Not applicable. This change affects deploy tooling, local workflow docs, and CSV version-log behavior; it does not change Flask routes or JSON API contracts.

## Browser Validation

Not applicable. This change has no browser-facing UI surface.

## Release Notes

### New Capabilities

- Added post-merge version-log recording so merged git refs are recorded before deploy.
- Renamed the default version CSV from `out/deploy/deploy_log.csv` to `out/deploy/version_log.csv`.
- Clarified protected merge and changelog workflows so `/changelog` owns the `APP_VERSION` bump and deploy logging verifies prepared versions.

### Fixed Bugs

- Fixed direct post-merge deploys so they reuse the merge-recorded version for the same git ref.
- Fixed deploy logging so new git refs record the already prepared `APP_VERSION` instead of incrementing at deploy time.
- Fixed repeated deploys of an already logged git ref so they reuse that git ref's recorded version even if local `.env` has advanced for a later release.

### Touched Models

- Version-log CSV versioning contract.
- `DeployLogSettings` deploy hook settings dataclass.

## Plan Status

No plan / planning skipped. This is a focused corrective merge requested after the protected-container versioning workflow showed a contract gap. The scope is limited to version-log behavior, merge/changelog instructions, docs, and tests.

## Review Checklist

- [x] Scope is limited to protected-container version ownership, version-log filename, and downstream root wrapper/docs.
- [x] `.env.secrets` and `.env.deploy.secrets` were not read.
- [x] `APP_VERSION=0.2.4` is prepared locally in ignored `.env` and `CHANGELOG.md` contains matching `0.2.4` notes.
- [x] New Python behavior has focused tests.
- [x] Changed Python avoids new loose `Any`/`object`/generic dict patterns.
- [x] Docs and workflow instructions describe post-merge version-log recording.
- [x] CI still needs to run after draft PR review, per repo preference.

## Residual Risks

- `out/deploy/version_log.csv` is a runtime artifact and ignored by Git. The post-merge command must run locally after main is pulled so the local deploy environment has the merge row before deploy.
- Root stock-dashboard has companion local changes that should be committed separately after the protected-container PR is merged and the submodule pointer is updated.